### PR TITLE
Bump package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5936,10 +5936,6 @@
         "node": "*"
       }
     },
-    "node_modules/nhsuk-prototype-rig/node_modules/nhsuk-prototype-rig": {
-      "resolved": "node_modules/nhsuk-prototype-rig",
-      "link": true
-    },
     "node_modules/nhsuk-prototype-rig/node_modules/rollup": {
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
@@ -9135,9 +9131,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.4.tgz",
-      "integrity": "sha512-/Je22Er4LPoln256pcLzj73MUmPrTWg8u4WB1RlxaDl0idJOfD1r259VtKOinp4xLJqJ9zYVMuWOun6Ssp7boA==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.5.tgz",
+      "integrity": "sha512-Nudle2CLcCaf9/1bVQunwzX1/ZH4Z6mvP8hkWWZCbKrxtnN52QwD5Xn/mo68aofQhGU4be1GlEC6LQCTKGXkRw==",
       "engines": {
         "node": ">=14.16"
       },
@@ -13978,146 +13974,6 @@
             "brace-expansion": "^1.1.7"
           }
         },
-        "nhsuk-prototype-rig": {
-          "version": "file:node_modules/nhsuk-prototype-rig",
-          "requires": {
-            "@rollup/plugin-commonjs": "^22.0.0",
-            "@rollup/plugin-node-resolve": "^13.0.5",
-            "browser-sync": "^2.27.8",
-            "client-sessions": "^0.8.0",
-            "cookie-parser": "^1.4.6",
-            "cosmiconfig": "^7.0.1",
-            "dotenv": "^16.0.0",
-            "express": "^4.17.3",
-            "express-rate-limit": "^6.4.0",
-            "express-session": "^1.13.0",
-            "govuk-frontend": "^4.5.0",
-            "govuk-prototype-components": "^1.0.0",
-            "govuk-prototype-wizard": "^0.2.0",
-            "inquirer": "^9.0.0",
-            "lodash": "^4.17.21",
-            "luxon": "^3.0.1",
-            "marked": "^4.0.12",
-            "mock-req-res": "^1.2.0",
-            "nhsuk-decorated-components": "^0.0.5",
-            "nhsuk-frontend": "^6.2.0",
-            "nhsuk-prototype-rig": "file:",
-            "nodemon": "^2.0.13",
-            "npm-run-all": "^4.1.5",
-            "nunjucks": "^3.2.1",
-            "portscanner": "^2.2.0",
-            "rollup": "^2.70.1",
-            "rollup-plugin-copy": "^3.4.0",
-            "rollup-plugin-scss": "^3.0.0",
-            "sass": "^1.49.9",
-            "validate.js": "^0.13.1"
-          },
-          "dependencies": {
-            "@rollup/plugin-commonjs": {
-              "version": "22.0.2",
-              "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
-              "integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
-              "requires": {
-                "@rollup/pluginutils": "^3.1.0",
-                "commondir": "^1.0.1",
-                "estree-walker": "^2.0.1",
-                "glob": "^7.1.6",
-                "is-reference": "^1.2.1",
-                "magic-string": "^0.25.7",
-                "resolve": "^1.17.0"
-              }
-            },
-            "@rollup/plugin-node-resolve": {
-              "version": "13.3.0",
-              "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
-              "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
-              "requires": {
-                "@rollup/pluginutils": "^3.1.0",
-                "@types/resolve": "1.17.1",
-                "deepmerge": "^4.2.2",
-                "is-builtin-module": "^3.1.0",
-                "is-module": "^1.0.0",
-                "resolve": "^1.19.0"
-              }
-            },
-            "@rollup/pluginutils": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-              "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-              "requires": {
-                "@types/estree": "0.0.39",
-                "estree-walker": "^1.0.1",
-                "picomatch": "^2.2.2"
-              },
-              "dependencies": {
-                "estree-walker": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-                  "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
-                }
-              }
-            },
-            "@types/estree": {
-              "version": "0.0.39",
-              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-              "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-            },
-            "@types/resolve": {
-              "version": "1.17.1",
-              "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
-              "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "glob": {
-              "version": "7.2.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-              "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "magic-string": {
-              "version": "0.25.9",
-              "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-              "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-              "requires": {
-                "sourcemap-codec": "^1.4.8"
-              }
-            },
-            "minimatch": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "rollup": {
-              "version": "2.79.1",
-              "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-              "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-              "requires": {
-                "fsevents": "~2.3.2"
-              }
-            }
-          }
-        },
         "rollup": {
           "version": "2.79.1",
           "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
@@ -16506,9 +16362,9 @@
       "peer": true
     },
     "type-fest": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.4.tgz",
-      "integrity": "sha512-/Je22Er4LPoln256pcLzj73MUmPrTWg8u4WB1RlxaDl0idJOfD1r259VtKOinp4xLJqJ9zYVMuWOun6Ssp7boA=="
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.5.tgz",
+      "integrity": "sha512-Nudle2CLcCaf9/1bVQunwzX1/ZH4Z6mvP8hkWWZCbKrxtnN52QwD5Xn/mo68aofQhGU4be1GlEC6LQCTKGXkRw=="
     },
     "type-is": {
       "version": "1.6.18",


### PR DESCRIPTION
Using a more recent version of npm, `9.4.1`, bumps the package lock.