### PR TITLE
Create a journey for explicitly syncing offline changes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -107,3 +107,33 @@ $color_app-pale-blue: #ccdff1;
     }
   }
 }
+
+@keyframes rotate {
+  0% {
+      transform: rotate(0deg);
+  }
+  100% {
+      transform: rotate(360deg);
+  }
+}
+
+@keyframes draw {
+  0% {
+      stroke-dashoffset: 125;
+  }
+  100% {
+      stroke-dashoffset: 0;
+  }
+}
+
+.loader {
+  width: 100px;
+  height: 100px;
+}
+
+.circle {
+  animation: draw 1.5s ease-in-out, pulse 10s ease-in;
+  animation-iteration-count: infinite, 1;
+  stroke-width: 10;
+  stroke-dasharray: 125;
+}

--- a/app/data.js
+++ b/app/data.js
@@ -15,6 +15,7 @@ import users from './generators/users.js'
 const c = campaigns({ count: 20 })
 
 export default {
+  support: 'record-childrens-vaccinations@service.nhs.uk',
   user: {
     name: 'Jane Doe',
     email: 'jane.doe@example.com'

--- a/app/routes.js
+++ b/app/routes.js
@@ -39,6 +39,8 @@ router.all('*', (req, res, next) => {
   res.locals.offlineUploaded = req.session.offlineUploaded
   res.locals.hasAnyOfflineChanges = hasAnyOfflineChanges(req.session.data.campaigns)
   res.locals.totalOfflineChangesCount = offlineChangesCount(req.session.data.campaigns)
+
+  res.locals.totalOfflineChangesCount = 100
   next()
 })
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -39,8 +39,6 @@ router.all('*', (req, res, next) => {
   res.locals.offlineUploaded = req.session.offlineUploaded
   res.locals.hasAnyOfflineChanges = hasAnyOfflineChanges(req.session.data.campaigns)
   res.locals.totalOfflineChangesCount = offlineChangesCount(req.session.data.campaigns)
-
-  res.locals.totalOfflineChangesCount = 100
   next()
 })
 

--- a/app/views/back-online.html
+++ b/app/views/back-online.html
@@ -1,0 +1,30 @@
+{% extends "layouts/default.html" %}
+{% set title = "You’re back online" %}
+
+{% block main %}
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="main-content" role="main">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-full">
+          <div class="nhsuk-card">
+            <div class="nhsuk-card__content">
+              <h1 class="nhsuk-heading-l">{{ title | noOrphans | safe }}</h1>
+
+              <p>{{ totalOfflineChangesCount }} offline changes need syncing.</p>
+
+              {{ button({
+                text: "Sync your changes",
+                href: "/synced-ok"
+              }) }}
+            </div>
+          </div>
+
+          <p>
+            <a href="#">Continue without syncing</a>
+          </p>
+          <p>You will need to sync your changes later.</p>
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/app/views/back-online.html
+++ b/app/views/back-online.html
@@ -8,7 +8,7 @@
         <div class="nhsuk-grid-column-full">
           <h1 class="nhsuk-heading-l">{{ title | noOrphans | safe }}</h1>
 
-          <p>{{ totalOfflineChangesCount }} offline changes need syncing.</p>
+          <p>{{ totalOfflineChangesCount or 52 }} offline changes need syncing.</p>
 
           {{ button({
             text: "Sync your changes",

--- a/app/views/back-online.html
+++ b/app/views/back-online.html
@@ -6,20 +6,18 @@
     <main class="nhsuk-main-wrapper" id="main-content" role="main">
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
-          <div class="nhsuk-card">
-            <div class="nhsuk-card__content">
-              <h1 class="nhsuk-heading-l">{{ title | noOrphans | safe }}</h1>
+          <h1 class="nhsuk-heading-l">{{ title | noOrphans | safe }}</h1>
 
-              <p>{{ totalOfflineChangesCount }} offline changes need syncing.</p>
+          <p>{{ totalOfflineChangesCount }} offline changes need syncing.</p>
 
-              {{ button({
-                text: "Sync your changes",
-                href: "/synced-ok"
-              }) }}
-            </div>
-          </div>
+          {{ button({
+            text: "Sync your changes",
+            href: "/synced-ok",
+            classes: "nhsuk-u-margin-bottom-2"
+          }) }}
 
-          <p>
+          <hr />
+          <p class="nhsuk-u-margin-bottom-2">
             <a href="#">Continue without syncing</a>
           </p>
           <p>You will need to sync your changes later.</p>

--- a/app/views/synced-error-try-again.html
+++ b/app/views/synced-error-try-again.html
@@ -1,0 +1,28 @@
+{% extends "layouts/default.html" %}
+{% set title = "We cannot sync your changes at the moment" %}
+
+{% block main %}
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="main-content" role="main">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+          <h1 class="nhsuk-heading-l">{{ title | noOrphans | safe }}</h1>
+
+          <p>The website is currently unavailable. A team is working to fix this.</p>
+
+          <p class="nhsuk-u-margin-bottom-6">Please try to sync your changes again later.</p>
+
+          {{ button({
+            text: "Continue working offline",
+            href: "/dashboard"
+          }) }}
+
+          <p class="nhsuk-u-margin-top-6">
+            If you keep seeing this message, contact support on:<br />
+            <a href="#">support@service.nhs.uk</a>
+          </p>
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/app/views/synced-error.html
+++ b/app/views/synced-error.html
@@ -1,0 +1,27 @@
+{% extends "layouts/default.html" %}
+{% set title = "We could not sync 3 of your changes" %}
+
+{% block main %}
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="main-content" role="main">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+          <h1 class="nhsuk-heading-l">{{ title | noOrphans | safe }}</h1>
+
+          <p>This can happen if:</p>
+
+          <ul class="nhsuk-list nhsuk-list--bullet">
+            <li>two people change the same record in different ways</li>
+          </ul>
+
+          <p>You need to review the changed records, and decide which version is correct.</p>
+
+          {{ button({
+            text: "Continue",
+            href: "/dashboard"
+          }) }}
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/app/views/synced-error.html
+++ b/app/views/synced-error.html
@@ -1,5 +1,5 @@
 {% extends "layouts/default.html" %}
-{% set title = "We could not sync 3 of your changes" %}
+{% set title = "There was a problem" %}
 
 {% block main %}
   <div class="nhsuk-width-container">
@@ -8,18 +8,40 @@
         <div class="nhsuk-grid-column-two-thirds">
           <h1 class="nhsuk-heading-l">{{ title | noOrphans | safe }}</h1>
 
-          <p>This can happen if:</p>
+          <h2 class="nhsuk-heading-m">3 changes had a problem</h2>
 
-          <ul class="nhsuk-list nhsuk-list--bullet">
-            <li>two people change the same record in different ways</li>
-          </ul>
+          <p>Sometimes two people can change the same record in different ways, this can create a conflict that needs to be reconciled by our support team.</p>
 
-          <p>You need to review the changed records, and decide which version is correct.</p>
+          <p>These changes have been sent to our support team to investigate. They will review them and contact you if they need more information. Fixes are usually simple and quick.</p>
+
+          <p>You’ll get an email when the problems are fixed.</p>
+
+          <p>Your changes are safe and no data has been lost.</p>
+
+          {{ details({
+            text: "See which changes had a problem",
+            HTML: "...",
+            classes: "nhsuk-u-margin-bottom-6"
+          }) }}
+
+          <h2 class="nhsuk-heading-m">Everything else synced successfully</h2>
+
+          {{ details({
+            text: "See your synced changes",
+            HTML: "...",
+            classes: "nhsuk-u-margin-bottom-6"
+          }) }}
 
           {{ button({
-            text: "Continue",
+            classes: "nhsuk-u-margin-top-4",
+            text: "Finish",
             href: "/dashboard"
           }) }}
+
+          <p>
+            If you have any questions you can contact:<br >
+            <a href="#">{{ data.support }}</a>
+          </p>
         </div>
       </div>
     </main>

--- a/app/views/synced-ok.html
+++ b/app/views/synced-ok.html
@@ -1,0 +1,26 @@
+{% extends "layouts/default.html" %}
+{% set title = "Your offline changes have synced successfully" %}
+
+{% block main %}
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="main-content" role="main">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+          <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-6">{{ title | noOrphans | safe }}</h1>
+
+          {{ details({
+            text: "See your synced changes",
+            HTML: "...",
+            classes: "nhsuk-u-margin-bottom-6"
+          }) }}
+
+          {{ button({
+            text: "Continue",
+            href: "/dashboard",
+            classes: "nhsuk-u-margin-bottom-3"
+          }) }}
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/app/views/synced-ok.html
+++ b/app/views/synced-ok.html
@@ -6,21 +6,39 @@
     <main class="nhsuk-main-wrapper" id="main-content" role="main">
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-          <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-6">{{ title | noOrphans | safe }}</h1>
+          <div id="syncing-changes">
+            <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-6">Syncing your changes</h1>
 
-          {{ details({
-            text: "See your synced changes",
-            HTML: "...",
-            classes: "nhsuk-u-margin-bottom-6"
-          }) }}
+            <svg class="loader" viewBox="0 0 50 50">
+              <circle class="circle" cx="25" cy="25" r="20" stroke="#005eb8" stroke-width="5" fill="none"></circle>
+            </svg>
+          </div>
 
-          {{ button({
-            text: "Continue",
-            href: "/dashboard",
-            classes: "nhsuk-u-margin-bottom-3"
-          }) }}
+          <div id="changes-synced" style="display: none">
+            <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-6">{{ title | noOrphans | safe }}</h1>
+            {{ details({
+              text: "See your synced changes",
+              HTML: "...",
+              classes: "nhsuk-u-margin-bottom-6"
+            }) }}
+
+            {{ button({
+              text: "Continue",
+              href: "/dashboard",
+              classes: "nhsuk-u-margin-bottom-3"
+            }) }}
+          </div>
         </div>
       </div>
     </main>
   </div>
+{% endblock %}
+
+{% block bodyEnd %}
+<script>
+  setTimeout(function() {
+    document.getElementById('syncing-changes').style.display = 'none';
+    document.getElementById('changes-synced').style.display = 'block';
+  }, 5000);
+</script>
 {% endblock %}


### PR DESCRIPTION
A follow-on from:
https://childhood-vaccinations.designhistory.app/manual-offline-syncing

- Page to enable manual sync
- A syncing and success page
- An error page if there was a conflict
- An error page if the site is down (but the user is online)

https://user-images.githubusercontent.com/319055/228227269-0856efaa-0454-4091-927a-56c29f5ceddf.mov

