### PR TITLE
Batch redesign

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -77,6 +77,12 @@ $color_app-pale-blue: #ccdff1;
   }
 }
 
+.app-table--no-bottom-border {
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
 .app-notification-banner {
   border-color: $color_nhsuk-blue;
 

--- a/app/data.js
+++ b/app/data.js
@@ -2,6 +2,7 @@ import campaigns from './generators/campaigns.js'
 import vaccinationRecord from './generators/vaccination-record.js'
 import triageRecord from './generators/triage-record.js'
 import users from './generators/users.js'
+import vaccines from './generators/vaccines.js'
 
 /**
  * Default values for user session data
@@ -21,6 +22,7 @@ export default {
     email: 'jane.doe@example.com'
   },
   campaigns: c,
+  vaccines: vaccines(),
   vaccination: vaccinationRecord(c),
   triage: triageRecord(c),
   users: users({ count: 20 }),

--- a/app/data.js
+++ b/app/data.js
@@ -2,7 +2,7 @@ import campaigns from './generators/campaigns.js'
 import vaccinationRecord from './generators/vaccination-record.js'
 import triageRecord from './generators/triage-record.js'
 import users from './generators/users.js'
-import vaccines from './generators/vaccines.js'
+import vaccineGenerator from './generators/vaccines.js'
 
 /**
  * Default values for user session data
@@ -14,6 +14,7 @@ import vaccines from './generators/vaccines.js'
  */
 
 const c = campaigns({ count: 20 })
+const vaccines = vaccineGenerator()
 
 export default {
   support: 'record-childrens-vaccinations@service.nhs.uk',
@@ -22,8 +23,8 @@ export default {
     email: 'jane.doe@example.com'
   },
   campaigns: c,
-  vaccines: vaccines(),
-  vaccination: vaccinationRecord(c),
+  vaccines,
+  vaccination: vaccinationRecord(c, vaccines.batches),
   triage: triageRecord(c),
   users: users({ count: 20 }),
   // Set feature flags using the `features` key

--- a/app/generators/campaign.js
+++ b/app/generators/campaign.js
@@ -1,6 +1,5 @@
 import school from './school.js'
 import children from './children.js'
-import vaccines from './vaccines.js'
 import yearGroups from './year-groups.js'
 import { faker } from '@faker-js/faker'
 import { DateTime } from 'luxon'
@@ -41,7 +40,6 @@ export default () => {
     type,
     triageInProgress,
     yearGroups: yearGroups(type),
-    vaccines: vaccines(type),
     school: schoolObject,
     isFlu: type === 'Flu',
     isHPV: type === 'HPV',

--- a/app/generators/campaign.js
+++ b/app/generators/campaign.js
@@ -23,9 +23,7 @@ const ageRange = (type) => {
 }
 
 export default () => {
-  // const type = faker.helpers.arrayElement(['Flu', 'HPV', '3-in-1 and MenACWY'])
   const type = 'HPV'
-  const vaccinesObject = vaccines(faker, type)
   const schoolObject = school(faker, type)
   const atTime = faker.helpers.arrayElement(['09:00', '10:00', '11:00', '12:30', '13:00', '14:00'])
   const daysUntil = faker.datatype.number({ min: 2, max: 100 })
@@ -43,7 +41,7 @@ export default () => {
     type,
     triageInProgress,
     yearGroups: yearGroups(type),
-    vaccines: vaccinesObject,
+    vaccines: vaccines(type),
     school: schoolObject,
     isFlu: type === 'Flu',
     isHPV: type === 'HPV',

--- a/app/generators/vaccination-record.js
+++ b/app/generators/vaccination-record.js
@@ -1,9 +1,18 @@
 import { faker } from '@faker-js/faker'
 
-export default (campaigns) => {
+export default (campaigns, batches) => {
   const campaign = Object.values(campaigns).find(c => c.inProgress)
   const campaignId = campaign.id
   const children = campaign.children
+
+  let batch = null
+  if (campaign.isFlu) {
+    batch = Object.values(batches).find(b => b.isFlu)
+  } else if (campaign.isHPV) {
+    batch = Object.values(batches).find(b => b.isHPV)
+  } else if (campaign.is3in1MenACWY) {
+    batch = Object.values(batches).find(b => b.isMenACWY || b.is3in1)
+  }
 
   const vr = {
     [campaignId]: {}
@@ -12,7 +21,8 @@ export default (campaigns) => {
   children.filter(c => c.outcome === 'Vaccinated').forEach(child => {
     vr[campaignId][child.nhsNumber] = {
       given: 'Yes',
-      where: 'Left arm'
+      where: 'Left arm',
+      batch
     }
   })
 

--- a/app/generators/vaccination-record.js
+++ b/app/generators/vaccination-record.js
@@ -22,7 +22,7 @@ export default (campaigns, batches) => {
     vr[campaignId][child.nhsNumber] = {
       given: 'Yes',
       where: 'Left arm',
-      batch
+      batch: batch.name
     }
   })
 

--- a/app/generators/vaccines.js
+++ b/app/generators/vaccines.js
@@ -10,11 +10,11 @@ const getBatches = () => {
   for (let i = 0; i < count; i++) {
     const name = `${prefix}${faker.phone.number('####')}`
     const daysUntilExpiry = faker.datatype.number({ min: 10, max: 50 })
-    const expiry = DateTime.now().plus({ days: daysUntilExpiry }).toISODate()
-    const day = expiry.split('-')[2]
-    const month = expiry.split('-')[1]
-    const year = expiry.split('-')[0]
-    batches[name] = { name, expiry: { year, month, day } }
+    const expiryDate = DateTime.now().plus({ days: daysUntilExpiry }).toISODate()
+    const day = expiryDate.split('-')[2]
+    const month = expiryDate.split('-')[1]
+    const year = expiryDate.split('-')[0]
+    batches[name] = { name, expiryDate, expiry: { year, month, day } }
   }
 
   return batches
@@ -25,7 +25,7 @@ const summarise = (v) => {
   v.summary = `${v.vaccine} (${brand})`
 }
 
-export default (type) => {
+export default () => {
   // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1107978/Influenza-green-book-chapter19-16September22.pdf
   const fluVaccines = [
     {
@@ -80,26 +80,8 @@ export default (type) => {
     }
   ]
 
-  let vacs
-  switch (type) {
-    case 'Flu':
-      vacs = fluVaccines
-      break
-    case 'HPV':
-      vacs = hpvVaccines
-      break
-    case '3-in-1 and MenACWY':
-      vacs = dptVaccines.concat(menAcwyVaccines)
-      break
-    default:
-      // concatenate all types
-      vacs = fluVaccines.concat(hpvVaccines, dptVaccines, menAcwyVaccines)
-  }
-
-  vacs.forEach(vaccine => {
-    vaccine.type = type
-    summarise(vaccine)
-  })
+  const vacs = fluVaccines.concat(hpvVaccines, dptVaccines, menAcwyVaccines)
+  vacs.forEach(vaccine => summarise(vaccine))
 
   const allBatches = {}
 

--- a/app/generators/vaccines.js
+++ b/app/generators/vaccines.js
@@ -33,12 +33,14 @@ export default (type) => {
       brand: 'Fluenz Tetra',
       method: 'Nasal spray',
       isNasal: true,
+      isFlu: true,
       batches: getBatches(faker)
     },
     {
       vaccine: 'Flu',
       brand: 'Fluarix Tetra',
       method: 'Injection',
+      isFlu: true,
       batches: getBatches(faker)
     }
   ]
@@ -49,6 +51,7 @@ export default (type) => {
       vaccine: 'HPV',
       brand: 'Gardasil 9',
       method: 'Injection',
+      isHPV: true,
       batches: getBatches(faker)
     }
   ]
@@ -60,6 +63,7 @@ export default (type) => {
       vaccine: '3-in-1',
       brand: 'Revaxis',
       method: 'Injection',
+      is3in1: true,
       batches: getBatches(faker)
     }
   ]
@@ -71,6 +75,7 @@ export default (type) => {
       vaccine: 'MenACWY',
       brand: 'Nimenrix',
       method: 'Injection',
+      isMenACWY: true,
       batches: getBatches(faker)
     }
   ]
@@ -100,11 +105,14 @@ export default (type) => {
 
   vacs.flatMap(v => v.batches).forEach(batches => {
     Object.keys(batches).forEach(name => {
-      const batch = batches[name]
-      batch.vaccine = vacs.find(v => v.batches[name]).vaccine
-      batch.brand = vacs.find(v => v.batches[name]).brand
-      batch.method = vacs.find(v => v.batches[name]).method
+      const batch = {
+        ...batches[name],
+        ...vacs.find(v => v.batches[name])
+      }
 
+      batch.summary = batch.summary.replace(')', `, ${name})`)
+
+      delete batch.batches
       allBatches[name] = batch
     })
   })

--- a/app/generators/vaccines.js
+++ b/app/generators/vaccines.js
@@ -1,6 +1,8 @@
 import { DateTime } from 'luxon'
+import { faker } from '@faker-js/faker'
+faker.locale = 'en_GB'
 
-const getBatches = (faker) => {
+const getBatches = () => {
   const batches = []
   const count = faker.datatype.number({ min: 1, max: 3 })
   const prefix = faker.random.alpha({ casing: 'upper', count: 2 })
@@ -20,7 +22,7 @@ const summarise = (v) => {
   v.summary = `${v.vaccine} (${brand}, ${v.batches[0].name})`
 }
 
-export default (faker, type) => {
+export default (type) => {
   // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1107978/Influenza-green-book-chapter19-16September22.pdf
   const fluVaccines = [
     {
@@ -81,6 +83,9 @@ export default (faker, type) => {
     case '3-in-1 and MenACWY':
       vacs = dptVaccines.concat(menAcwyVaccines)
       break
+    default:
+      // concatenate all types
+      vacs = fluVaccines.concat(hpvVaccines, dptVaccines, menAcwyVaccines)
   }
 
   vacs.forEach(vaccine => {

--- a/app/routes.js
+++ b/app/routes.js
@@ -7,6 +7,7 @@ import userRoutes from './routes/user.js'
 import onlineOfflineRoutes from './routes/online-offline.js'
 import redirects from './routes/redirects.js'
 import consent from './routes/consent.js'
+import vaccineBatchRoutes from './routes/vaccine-batches.js'
 
 const router = express.Router()
 
@@ -49,6 +50,7 @@ userRoutes(router)
 onlineOfflineRoutes(router, hasAnyOfflineChanges)
 redirects(router)
 consent(router)
+vaccineBatchRoutes(router)
 
 router.get('/dashboard', (req, res, next) => {
   res.locals.hasAnyOfflineChanges = hasAnyOfflineChanges(req.session.data.campaigns)

--- a/app/routes/vaccination.js
+++ b/app/routes/vaccination.js
@@ -56,6 +56,21 @@ export default (router) => {
   })
 
   router.all([
+    '/vaccination/:campaignId/:nhsNumber/which-batch'
+  ], (req, res, next) => {
+    res.locals.batchItems = res.locals.campaign.vaccines[0].batches.map(v => {
+      return {
+        text: `${v.name} (${v.expiry})`,
+        value: v.name
+      }
+    })
+
+    res.locals.batchItems.push({ divider: 'or' })
+    res.locals.batchItems.push({ text: 'A batch that’s not in this list' })
+    next()
+  })
+
+  router.all([
     '/vaccination/:campaignId/:nhsNumber/details'
   ], (req, res, next) => {
     res.locals['3in1VaccinationRecord'] = _.get(req.session.data, `3-in-1-vaccination.${req.params.campaignId}.${req.params.nhsNumber}`)

--- a/app/routes/vaccination.js
+++ b/app/routes/vaccination.js
@@ -58,15 +58,14 @@ export default (router) => {
   router.all([
     '/vaccination/:campaignId/:nhsNumber/which-batch'
   ], (req, res, next) => {
-    res.locals.batchItems = res.locals.campaign.vaccines[0].batches.map(v => {
-      return {
-        text: `${v.name} (${v.expiry})`,
-        value: v.name
-      }
-    })
+    const campaignType = res.locals.campaign.type
+    const batchesForCampaign = Object
+      .values(req.session.data.vaccines.batches)
+      .filter(b => b.vaccine === campaignType)
 
-    res.locals.batchItems.push({ divider: 'or' })
-    res.locals.batchItems.push({ text: 'A batch that’s not in this list' })
+    console.log(campaignType, req.session.data.vaccines.batches, batchesForCampaign, batchesForCampaign.map(v => v.name))
+
+    res.locals.batchItems = batchesForCampaign.map(v => v.name)
     next()
   })
 
@@ -102,6 +101,7 @@ export default (router) => {
 
     if (vaccineGiven) {
       res.locals.child.outcome = 'Vaccinated'
+      res.locals.child.batch = res.locals.vaccinationRecord.batch
       res.locals.child.seen = { text: 'Vaccinated', given: vaccineGiven }
     } else {
       res.locals.child.outcome = 'Could not vaccinate'

--- a/app/routes/vaccine-batches.js
+++ b/app/routes/vaccine-batches.js
@@ -1,0 +1,5 @@
+export default (router) => {
+  router.get('/vaccines', (req, res, next) => {
+    next()
+  })
+}

--- a/app/routes/vaccine-batches.js
+++ b/app/routes/vaccine-batches.js
@@ -1,4 +1,16 @@
+const sortByExpiryDate = (batches) => {
+  return batches.sort((a, b) => {
+    return new Date(a.expiryDate) - new Date(b.expiryDate)
+  })
+}
+
 export default (router) => {
+  router.get('/vaccines', (req, res, next) => {
+    const batches = Object.values(req.session.data.vaccines.batches)
+    res.locals.batches = sortByExpiryDate(batches)
+    next()
+  })
+
   router.get('/vaccines/:batchNumber', (req, res) => {
     res.locals.batch = req.session.data.vaccines.batches[req.params.batchNumber]
     res.render('vaccines/batch')

--- a/app/routes/vaccine-batches.js
+++ b/app/routes/vaccine-batches.js
@@ -1,29 +1,6 @@
-const mapVaccineData = (data) => {
-  const map = {}
-  data.forEach(vaccine => {
-    vaccine.batches.forEach(batch => {
-      map[batch.name] = {
-        name: batch.name,
-        vaccine: vaccine.vaccine,
-        brand: vaccine.brand,
-        method: vaccine.method,
-        expiry: batch.expiry
-      }
-    })
-  })
-
-  return map
-}
-
 export default (router) => {
-  router.get('/vaccines', (req, res, next) => {
-    next()
-  })
-
   router.get('/vaccines/:batchNumber', (req, res) => {
-    const batches = mapVaccineData(req.session.data.vaccines)
-    res.locals.batch = batches[req.params.batchNumber]
-
+    res.locals.batch = req.session.data.vaccines.batches[req.params.batchNumber]
     res.render('vaccines/batch')
   })
 }

--- a/app/routes/vaccine-batches.js
+++ b/app/routes/vaccine-batches.js
@@ -1,5 +1,29 @@
+const mapVaccineData = (data) => {
+  const map = {}
+  data.forEach(vaccine => {
+    vaccine.batches.forEach(batch => {
+      map[batch.name] = {
+        name: batch.name,
+        vaccine: vaccine.vaccine,
+        brand: vaccine.brand,
+        method: vaccine.method,
+        expiry: batch.expiry
+      }
+    })
+  })
+
+  return map
+}
+
 export default (router) => {
   router.get('/vaccines', (req, res, next) => {
     next()
+  })
+
+  router.get('/vaccines/:batchNumber', (req, res) => {
+    const batches = mapVaccineData(req.session.data.vaccines)
+    res.locals.batch = batches[req.params.batchNumber]
+
+    res.render('vaccines/batch')
   })
 }

--- a/app/views/campaign/_children-banner.html
+++ b/app/views/campaign/_children-banner.html
@@ -13,7 +13,7 @@
       </p>
     {% endif %}
     <p>
-      <a href="/campaign/{{ campaignId }}/child/{{ successChild.nhsNumber }}">View child record</a>
+      <a href="/campaign/{{ campaign.id }}/child/{{ successChild.nhsNumber }}">View child record</a>
     </p>
   {% endset %}
 
@@ -37,7 +37,7 @@
       </p>
     {% endif %}
     <p>
-      <a href="/campaign/{{ campaignId }}/child/{{ successChild.nhsNumber }}">View child record</a>
+      <a href="/campaign/{{ campaign.id }}/child/{{ successChild.nhsNumber }}">View child record</a>
     </p>
   {% endset %}
 

--- a/app/views/campaign/child/_vaccination-recorded.html
+++ b/app/views/campaign/child/_vaccination-recorded.html
@@ -6,7 +6,7 @@
     rows: decorateRows([
       {
         key: 'Vaccine',
-        value: campaign.vaccines[0].summary
+        value: vaccinationRecord.batch.summary
       },
       {
         key: 'Dose',
@@ -19,11 +19,11 @@
       {
         key: 'Site',
         value: 'Nasal'
-      } if vaccineGiven and campaign.vaccines[0].method == "Nasal spray",
+      } if vaccineGiven and vaccinationRecord.batch.isNasal,
       {
         key: 'Site',
         value: vaccinationRecord.where
-      } if vaccineGiven and campaign.vaccines[0].method == "Injection",
+      } if vaccineGiven and not vaccinationRecord.batch.isNasal,
       {
         key: 'Reason',
         value: vaccinationRecord['why-not-given']

--- a/app/views/campaign/child/_vaccination-recorded.html
+++ b/app/views/campaign/child/_vaccination-recorded.html
@@ -1,12 +1,13 @@
 {% set vaccineRecorded %}
   <p><a href="#">Change</a></p>
+  {% set batch = data.vaccines.batches[vaccinationRecord.batch] %}
 
   {{ govukSummaryList({
     classes: "app-u-frutiger app-summary-list--no-bottom-border  nhsuk-u-margin-bottom-0",
     rows: decorateRows([
       {
         key: 'Vaccine',
-        value: vaccinationRecord.batch.summary
+        value: batch.summary
       },
       {
         key: 'Dose',
@@ -19,11 +20,11 @@
       {
         key: 'Site',
         value: 'Nasal'
-      } if vaccineGiven and vaccinationRecord.batch.isNasal,
+      } if vaccineGiven and batch.isNasal,
       {
         key: 'Site',
         value: vaccinationRecord.where
-      } if vaccineGiven and not vaccinationRecord.batch.isNasal,
+      } if vaccineGiven and not batch.isNasal,
       {
         key: 'Reason',
         value: vaccinationRecord['why-not-given']

--- a/app/views/campaign/index.html
+++ b/app/views/campaign/index.html
@@ -65,10 +65,6 @@
                 {% endif %}
 
                 <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-3">
-                  <a href="/campaign/{{ campaign.id }}/vaccines">Manage vaccine batches</a>
-                </h2>
-
-                <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-3">
                   <a href="#">Edit session</a>
                 </h2>
               </div>

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -16,26 +16,26 @@
 
           <h1 class="nhsuk-heading-xl">{{ title | noOrphans | safe }}</h1>
 
-          <!-- <div class="nhsuk-card">
-            <div class="nhsuk-card__content"> -->
-              <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
-                <a href="/school-sessions">School sessions</a>
-              </h2>
-              <p>Manage sessions and record vaccinations</p>
+          <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
+            <a href="/school-sessions">School sessions</a>
+          </h2>
+          <p>Manage sessions and record vaccinations</p>
 
-              <hr />
+          <h2 class="nhsuk-heading-m">
+            <a href="/school-sessions">Manage vaccine batches</a>
+          </h2>
 
-              <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
-                <a href="#">Your account</a>
-              </h2>
-              <p>Change your email address or password</p>
+          <hr />
 
-              <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
-                <a href="/manage-users">Manage team</a>
-              </h2>
-              <p>Add or remove team members and set permissions</p>
-            <!-- </div>
-          </div> -->
+          <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
+            <a href="/manage-users">Manage team</a>
+          </h2>
+          <p>Add or remove team members and set permissions</p>
+
+          <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
+            <a href="#">Your account</a>
+          </h2>
+          <p>Change your email address or password</p>
         </div>
       </div>
     </main>

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -21,9 +21,10 @@
           </h2>
           <p>Manage sessions and record vaccinations</p>
 
-          <h2 class="nhsuk-heading-m">
-            <a href="/school-sessions">Manage vaccine batches</a>
+          <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
+            <a href="/vaccines">Manage vaccine batches</a>
           </h2>
+          <p>Add or remove batches</p>
 
           <hr />
 

--- a/app/views/vaccination/_single-vaccine-details.html
+++ b/app/views/vaccination/_single-vaccine-details.html
@@ -6,11 +6,13 @@
   {% set rootPath = '/men-acwy-vaccination/' %}
   {% set index = 1 %}
 {% endif %}
-{% set vaccine = campaign.vaccines[index] %}
-{% set batch = vaccine.batches[0] %}
-{% set brand = vaccine.brand + ' (Nasal spray)' if vaccine.isNasal else vaccine.brand + ' (Injection)' %}
+{% set batchKey = vaccinationRecord.batch %}
+{% set batch = data.vaccines.batches[batchKey] %}
+{% set brand = batch.brand + ' (Nasal spray)' if batch.isNasal else batch.brand + ' (Injection)' %}
 {% set vaccineGiven = vaccinationRecord['given'] !== 'No' %}
 {% set basePath = rootPath + campaign.id + '/' + child.nhsNumber %}
+
+{{ vaccine.summary }}
 
 {{ govukSummaryList({
   classes: "app-u-frutiger app-summary-list--no-bottom-border",
@@ -21,7 +23,7 @@
     },
     {
       key: "Vaccine",
-      value: vaccine.vaccine
+      value: batch.vaccine
     },
     {
       key: "Dose",
@@ -35,7 +37,7 @@
     },
     {
       key: "Batch",
-      value: batch.name + ' (expires ' + (batch.expiry | govukDate('truncate')) + ')',
+      value: batch.name + ' (expires ' + (batch.expiryDate | govukDate('truncate')) + ')',
       href: "#"
     },
     {

--- a/app/views/vaccination/which-batch.html
+++ b/app/views/vaccination/which-batch.html
@@ -39,6 +39,25 @@
     {{ default | safe }}
   {% endset %}
 
+  {% set items = [] %}
+  {% for batchKey in batchItems %}
+    {% set batch = data.vaccines.batches[batchKey] %}
+    {% set items = (items.push({
+      text: batch.name + ' (expires ' + batch.expiryDate | govukDate + ')',
+      value: batchKey,
+      conditional: {
+        html: default
+      }
+    }), items) %}
+  {% endfor %}
+
+  {% set items = (items.push({ divider: 'or' }, {
+    text: 'A batch that’s not in this list',
+    conditional: {
+      html: otherBatch
+    }
+  }), items) %}
+
   {{ radios({
     fieldset: {
       legend: {
@@ -46,28 +65,8 @@
         text: title
       }
     },
-    items: [
-      {
-        text: 'GT1217 (10 July 2023)',
-        conditional: {
-          html: default
-        }
-      },
-      {
-        text: 'GT2237 (1 August 2023)',
-        conditional: {
-          html: default
-        }
-      },
-      { divider: 'or' },
-      {
-        text: 'A batch that’s not in this list',
-        conditional: {
-          html: otherBatch
-        }
-      }
-    ],
-    decorate: "batch"
+    items: items,
+    decorate: [dataLocation, campaign.id, child.nhsNumber, "batch"]
   }) }}
 
 {% endblock %}

--- a/app/views/vaccination/which-batch.html
+++ b/app/views/vaccination/which-batch.html
@@ -2,14 +2,7 @@
 {% set title = "Which batch did you use?" %}
 
 {% block form %}
-  {% set default %}
-    {{ checkboxes({
-      items: [
-        { text: 'Default to this batch for today' }
-      ],
-      decorate: "batch-default"
-    }) }}
-  {% endset %}
+  {% set defaulText = 'Default to this batch for today' %}
 
   {% set otherBatch %}
     {{ input({
@@ -17,9 +10,8 @@
         text: 'Batch',
         classes: 'nhsuk-label--s nhsuk-u-margin-bottom-1'
       },
-      value: batch.name,
       classes: 'nhsuk-input--width-10',
-      decorate: "users.new.fullName"
+      decorate: "other-batch-name"
     }) }}
 
     {{ dateInput({
@@ -30,13 +22,17 @@
         }
       },
       hint: {
-        text: "For example, 27 10 2023"
+        text: "For example, 31 12 2023"
       },
-      value: batch.expiry,
-      decorate: "expiry"
+      decorate: "other-batch-expiry"
     }) }}
 
-    {{ default | safe }}
+    {{ checkboxes({
+      items: [
+        { text: defaulText, value: "other-batch" }
+      ],
+      decorate: "todays-batch-other"
+    }) }}
   {% endset %}
 
   {% set items = [] %}
@@ -46,7 +42,12 @@
       text: batch.name + ' (expires ' + batch.expiryDate | govukDate + ')',
       value: batchKey,
       conditional: {
-        html: default
+        html: checkboxes({
+                items: [
+                  { text: defaulText, value: batchKey }
+                ],
+                decorate: "todays-batch-" + batchKey
+              })
       }
     }), items) %}
   {% endfor %}

--- a/app/views/vaccination/which-batch.html
+++ b/app/views/vaccination/which-batch.html
@@ -1,0 +1,73 @@
+{% extends "layouts/wizard.html" %}
+{% set title = "Which batch did you use?" %}
+
+{% block form %}
+  {% set default %}
+    {{ checkboxes({
+      items: [
+        { text: 'Default to this batch for today' }
+      ],
+      decorate: "batch-default"
+    }) }}
+  {% endset %}
+
+  {% set otherBatch %}
+    {{ input({
+      label: {
+        text: 'Batch',
+        classes: 'nhsuk-label--s nhsuk-u-margin-bottom-1'
+      },
+      value: batch.name,
+      classes: 'nhsuk-input--width-10',
+      decorate: "users.new.fullName"
+    }) }}
+
+    {{ dateInput({
+      fieldset: {
+        legend: {
+          text: "Expiry date",
+          classes: "nhsuk-fieldset__legend--s nhsuk-u-margin-bottom-1"
+        }
+      },
+      hint: {
+        text: "For example, 27 10 2023"
+      },
+      value: batch.expiry,
+      decorate: "expiry"
+    }) }}
+
+    {{ default | safe }}
+  {% endset %}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--l",
+        text: title
+      }
+    },
+    items: [
+      {
+        text: 'GT1217 (10 July 2023)',
+        conditional: {
+          html: default
+        }
+      },
+      {
+        text: 'GT2237 (1 August 2023)',
+        conditional: {
+          html: default
+        }
+      },
+      { divider: 'or' },
+      {
+        text: 'A batch that’s not in this list',
+        conditional: {
+          html: otherBatch
+        }
+      }
+    ],
+    decorate: "batch"
+  }) }}
+
+{% endblock %}

--- a/app/views/vaccines.html
+++ b/app/views/vaccines.html
@@ -35,7 +35,7 @@
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
-                {% for key, batch in data.vaccines.batches %}
+                {% for batch in batches %}
                   {% if batch.brand == vaccine.brand %}
                   <tr class="govuk-table__row">
                     <td class="govuk-table__cell">{{ batch.name }}</td>

--- a/app/views/vaccines.html
+++ b/app/views/vaccines.html
@@ -8,7 +8,6 @@
   }) }}
 {% endblock %}
 
-
 {% block main %}
   <div class="nhsuk-width-container">
     <main class="nhsuk-main-wrapper" id="main-content" role="main">
@@ -18,7 +17,7 @@
 
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-          {% for vaccine in data.vaccines %}
+          {% for vaccine in data.vaccines.brands %}
           <div class="nhsuk-card">
             <div class="nhsuk-card__content">
             <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">{{ vaccine.brand }} ({{ vaccine.vaccine }})</h2>
@@ -36,17 +35,19 @@
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
-                {% for batch in vaccine.batches %}
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">{{ batch.name }}</td>
-                  <td class="govuk-table__cell">{{ batch.expiry | govukDate }}</td>
-                  <td class="govuk-table__cell nhsuk-u-text-align-right">
-                    <a href="/vaccines/{{ batch.name }}">Change</a>
-                  </td>
-                  <td class="govuk-table__cell nhsuk-u-text-align-right">
-                    <a href="#">Move&nbsp;to&nbsp;archive</a>
-                  </td>
-                </tr>
+                {% for key, batch in data.vaccines.batches %}
+                  {% if batch.brand == vaccine.brand %}
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{ batch.name }}</td>
+                    <td class="govuk-table__cell">{{ batch.expiry | isoDateFromDateInput | govukDate }}</td>
+                    <td class="govuk-table__cell nhsuk-u-text-align-right">
+                      <a href="/vaccines/{{ batch.name }}">Change</a>
+                    </td>
+                    <td class="govuk-table__cell nhsuk-u-text-align-right">
+                      <a href="#">Move&nbsp;to&nbsp;archive</a>
+                    </td>
+                  </tr>
+                  {% endif %}
                 {% endfor %}
               </tbody>
             </table>

--- a/app/views/vaccines.html
+++ b/app/views/vaccines.html
@@ -18,81 +18,42 @@
 
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
+          {% for vaccine in data.vaccines %}
           <div class="nhsuk-card">
             <div class="nhsuk-card__content">
-              {% for vaccine in data.vaccines %}
-                <h2 class="nhsuk-heading-m">{{ vaccine.brand }} ({{ vaccine.vaccine }})</h2>
+            <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">{{ vaccine.brand }} ({{ vaccine.vaccine }})</h2>
+            <p>
+              <a href="#">Add a batch</a>
+            </p>
 
-                {% set batchesHtml %}
-                  <ul class="nhsuk-list">
-                    {% for batch in vaccine.batches %}
-                      <li>
-                        {{ batch.name }}<br />
-                        <span class="nhsuk-u-font-size-16">Expires {{ batch.expiry | govukDate }}</span>
-                      </li>
-                    {% endfor %}
-                    <p>
-                      <a href="#">Manage batches</a>
-                    </p>
-                  </ul>
-                {% endset %}
-
-                <table class="govuk-table">
-                  <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                      <th class="govuk-table__header" style="width: 30%">Batch</th>
-                      <th class="govuk-table__header" style="width: 50%">Expiry</th>
-                      <th class="govuk-table__header"></th>
-                    </tr>
-                  </thead>
-                  <tbody class="govuk-table__body">
-                    {% for batch in vaccine.batches %}
-                    <tr class="govuk-table__row">
-                      <td class="govuk-table__cell">{{ batch.name }}</td>
-                      <td class="govuk-table__cell">{{ batch.expiry | govukDate }}</td>
-                      <td class="govuk-table__cell nhsuk-u-text-align-right">
-                        <a href="#">Remove</a>
-                      </td>
-                    </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-
-                <p>
-                  <a href="#">Add a batch</a><br />
-                  <a href="#">Change vaccine</a>
-                </p>
-
-                <!-- {{ govukSummaryList({
-                  classes: "app-u-frutiger app-summary-list--no-bottom-border",
-                  rows: decorateRows([
-                    {
-                      key: 'Type',
-                      value: vaccine.vaccine
-                    },
-                    {
-                      key: 'Brand',
-                      value: vaccine.brand
-                    },
-                    {
-                      key: 'Method',
-                      value: vaccine.method
-                    },
-                    {
-                      key: 'Batches',
-                      value: {
-                        html: batchesHtml
-                      }
-                    }
-                  ])
-                }) }} -->
-              {% endfor %}
-
-              <p class="nhsuk-u-margin-top-6">
-                <a href="#" class="nhsuk-button">Add another vaccine</a>
-              </p>
+            <table class="govuk-table app-table--no-bottom-border">
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th class="govuk-table__header" style="width: 30%">Batch</th>
+                  <th class="govuk-table__header" style="width: 50%">Expiry</th>
+                  <th class="govuk-table__header"></th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                {% for batch in vaccine.batches %}
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">{{ batch.name }}</td>
+                  <td class="govuk-table__cell">{{ batch.expiry | govukDate }}</td>
+                  <td class="govuk-table__cell nhsuk-u-text-align-right">
+                    <a href="#">Move&nbsp;to&nbsp;archive</a>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
             </div>
           </div>
+          {% endfor %}
+
+          <p class="nhsuk-u-margin-top-6">
+            <a href="#" class="nhsuk-button">Add a new vaccine</a>
+          </p>
+
         </div>
       </div>
     </main>

--- a/app/views/vaccines.html
+++ b/app/views/vaccines.html
@@ -3,18 +3,8 @@
 
 {% block pageNavigation %}
   {{ breadcrumb({
-    items: [
-      {
-        text: "Home",
-        href: "/dashboard"
-      },
-      {
-        text: "School sessions",
-        href: "/school-sessions"
-      }
-    ],
-    text: campaign.title,
-    href: "/campaign/" + campaign.id
+    text: "Home",
+    href: "/dashboard"
   }) }}
 {% endblock %}
 
@@ -22,29 +12,6 @@
 {% block main %}
   <div class="nhsuk-width-container">
     <main class="nhsuk-main-wrapper" id="main-content" role="main">
-      {% if success %}
-        {% set html %}
-          {% if isOffline %}
-            <p class="govuk-notification-banner__heading">
-              Offline changes saved
-            </p>
-            <p>
-              You will need to go online to sync your changes.
-            </p>
-          {% else %}
-            <p class="govuk-notification-banner__heading">
-              Record saved
-            </p>
-          {% endif %}
-        {% endset %}
-
-        {{ govukNotificationBanner({
-          html: html,
-          classes: "app-u-frutiger",
-          type: "success"
-        }) }}
-      {% endif %}
-
       <h1 class="nhsuk-heading-l">
         {{ title | noOrphans | safe }}
       </h1>
@@ -53,7 +20,7 @@
         <div class="nhsuk-grid-column-two-thirds">
           <div class="nhsuk-card">
             <div class="nhsuk-card__content">
-              {% for vaccine in campaign.vaccines %}
+              {% for vaccine in data.vaccines %}
                 <h2 class="nhsuk-heading-m">{{ vaccine.brand }} ({{ vaccine.vaccine }})</h2>
 
                 {% set batchesHtml %}

--- a/app/views/vaccines.html
+++ b/app/views/vaccines.html
@@ -32,6 +32,7 @@
                   <th class="govuk-table__header" style="width: 30%">Batch</th>
                   <th class="govuk-table__header" style="width: 50%">Expiry</th>
                   <th class="govuk-table__header"></th>
+                  <th class="govuk-table__header"></th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
@@ -39,6 +40,9 @@
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell">{{ batch.name }}</td>
                   <td class="govuk-table__cell">{{ batch.expiry | govukDate }}</td>
+                  <td class="govuk-table__cell nhsuk-u-text-align-right">
+                    <a href="/vaccines/{{ batch.name }}">Change</a>
+                  </td>
                   <td class="govuk-table__cell nhsuk-u-text-align-right">
                     <a href="#">Move&nbsp;to&nbsp;archive</a>
                   </td>

--- a/app/views/vaccines/batch.html
+++ b/app/views/vaccines/batch.html
@@ -1,0 +1,57 @@
+{% extends "layouts/default.html" %}
+{% set title = "Edit batch" %}
+
+{% block pageNavigation %}
+<div class="nhsuk-width-container">
+  {{ backLink({
+    href: "/vaccines",
+    classes: "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-0"
+  }) }}
+</div>
+{% endblock %}
+
+{% block main %}
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="main-content" role="main">
+      <h1 class="nhsuk-heading-l">
+        <span class="nhsuk-caption-l">{{ batch.brand }}</span>
+        {{ title | noOrphans | safe }}
+      </h1>
+
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+          <form method="post">
+            {{ input({
+              label: {
+                text: 'Batch',
+                classes: 'nhsuk-label--s nhsuk-u-margin-bottom-1'
+              },
+              value: batch.name,
+              classes: 'nhsuk-input--width-10',
+              decorate: "users.new.fullName"
+            }) }}
+
+            {{ dateInput({
+              fieldset: {
+                legend: {
+                  text: "Expiry date",
+                  classes: "nhsuk-fieldset__legend--s nhsuk-u-margin-bottom-1"
+                }
+              },
+              hint: {
+                text: "For example, 27 10 2023"
+              },
+              value: batch.expiry,
+              decorate: "expiry"
+            }) }}
+
+            {{ button({
+              text: 'Save changes',
+              classes: 'nhsuk-u-margin-top-3'
+            }) }}
+          </form>
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/app/views/vaccines/batch.html
+++ b/app/views/vaccines/batch.html
@@ -26,9 +26,8 @@
                 text: 'Batch',
                 classes: 'nhsuk-label--s nhsuk-u-margin-bottom-1'
               },
-              value: batch.name,
               classes: 'nhsuk-input--width-10',
-              decorate: "users.new.fullName"
+              decorate: 'vaccines.batches.' + batch.name + '.name'
             }) }}
 
             {{ dateInput({
@@ -41,8 +40,7 @@
               hint: {
                 text: "For example, 27 10 2023"
               },
-              value: batch.expiry,
-              decorate: "expiry"
+              decorate: 'vaccines.batches.' + batch.name + '.expiry'
             }) }}
 
             {{ button({

--- a/app/wizards/vaccination.js
+++ b/app/wizards/vaccination.js
@@ -8,6 +8,7 @@ const getData = (data, keyPath) => {
 const journeyForEverythingElse = (data, campaign, child) => {
   const nhsNumber = child.nhsNumber
   const campaignId = campaign.id
+  const hasDefaultBatch = !!data.todaysBatch
   const isUnknown = child.consent.unknown || child.consent[campaign.type] === 'Unknown'
   const refused = child.consent.refusedBoth || child.consent[campaign.type] === 'Refused'
   const hasConsent = !(isUnknown || refused)
@@ -36,6 +37,12 @@ const journeyForEverythingElse = (data, campaign, child) => {
   if (!hasConsent && !askingForConsent) {
     return {
       [`/campaign/${campaignId}/children?noConsent=${nhsNumber}`]: {}
+    }
+  }
+
+  if (!hasDefaultBatch) {
+    return {
+      [`/vaccination/${campaignId}/${nhsNumber}/which-batch`]: {}
     }
   }
 

--- a/app/wizards/vaccination.js
+++ b/app/wizards/vaccination.js
@@ -8,7 +8,7 @@ const getData = (data, keyPath) => {
 const journeyForEverythingElse = (data, campaign, child) => {
   const nhsNumber = child.nhsNumber
   const campaignId = campaign.id
-  const hasDefaultBatch = !!data.todaysBatch
+  const hasDefaultBatch = !!data['todays-batch']
   const isUnknown = child.consent.unknown || child.consent[campaign.type] === 'Unknown'
   const refused = child.consent.refusedBoth || child.consent[campaign.type] === 'Refused'
   const hasConsent = !(isUnknown || refused)


### PR DESCRIPTION
https://childhood-vaccinations.designhistory.app/managing-vaccine-batches

- Manage vaccines from the dashboard, rather than per school session
- Ask which batch is being used when vaccinating
- Allow users to pick a default batch for the day (we will not ask for the batch again that day)
- Add links for adding, archiving and changing batches – designs not implemented

Some data cleanups:

- a vaccination record now contains a batch number which is used as a reference to the vaccine details
- no vaccines are kept against the campaign any more