### PR TITLE
Allow users to get consent during triage

### DIFF
--- a/app/enums.js
+++ b/app/enums.js
@@ -49,3 +49,12 @@ export const MEDICAL = {
   YES: 'Yes',
   NO: 'No medical notes'
 }
+
+export const REFUSAL_REASON = {
+  GELATINE: 'Vaccine contains gelatine from pigs',
+  ALREADY_GIVEN: 'Vaccine already received',
+  GETTING_ELSEWHERE: 'Vaccine will be given elsewhere',
+  MEDICAL: 'Medical reasons',
+  PERSONAL: 'Personal choice',
+  OTHER: 'Other'
+}

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -60,7 +60,6 @@ export default (options) => {
   c.dob = dateOfBirth(faker, options)
   c.age = age(c.dob)
   c.yearGroup = yearGroup(c.dob)
-  c.parentOrGuardian = parent(faker, c.lastName)
   c.consent = consent(faker, options.type)
   c.outcome = OUTCOME.NO_OUTCOME_YET
 
@@ -84,6 +83,10 @@ export default (options) => {
     'In person',
     'Paper'
   ])
+
+  if (c.consent.responded) {
+    c.parentOrGuardian = parent(faker, c.lastName)
+  }
 
   return c
 }

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -84,9 +84,6 @@ export default (options) => {
     'Paper'
   ])
 
-  if (c.consent.responded) {
-    c.parentOrGuardian = parent(faker, c.lastName)
-  }
-
+  c.parentOrGuardian = c.consent.responded ? parent(faker, c.lastName) : {}
   return c
 }

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -1,4 +1,4 @@
-import { CONSENT } from '../enums.js'
+import { CONSENT, REFUSAL_REASON } from '../enums.js'
 
 export default (faker, type) => {
   if (type === '3-in-1 and MenACWY') {
@@ -43,11 +43,23 @@ export default (faker, type) => {
     CONSENT.REFUSED
   ])
 
+  let reason = null
+  if (r === CONSENT.REFUSED) {
+    let availableReasons = Object.values(REFUSAL_REASON)
+    if (type !== 'Flu') {
+      availableReasons = availableReasons.filter(a => {
+        return a !== REFUSAL_REASON.GELATINE
+      })
+    }
+    reason = faker.helpers.arrayElement(availableReasons)
+  }
+
   return {
     [type]: r,
     text: r,
     refused: r === CONSENT.REFUSED,
     consented: r === CONSENT.GIVEN,
-    responded: r !== CONSENT.UNKNOWN
+    responded: r !== CONSENT.UNKNOWN,
+    reason
   }
 }

--- a/app/generators/parent.js
+++ b/app/generators/parent.js
@@ -29,5 +29,6 @@ export default (faker, lastName) => {
   p.relationship = relationship === 'Parent' ? parent : relationship
   p.email = faker.internet.email(p.firstName, p.lastName)
 
+  delete p.sex
   return p
 }

--- a/app/generators/triage-needed.js
+++ b/app/generators/triage-needed.js
@@ -5,7 +5,7 @@ export default (faker, child) => {
   child.needsTriage = false
   if (!child.consent.consented) return
 
-  if (child.parentOrGuardian.queryRelationship) {
+  if (child.parentOrGuardian && child.parentOrGuardian.queryRelationship) {
     child.needsTriage = true
     child.actionNeeded = ACTION_NEEDED.TRIAGE
     reasons.push(TRIAGE_REASON.CHECK_CONSENTER)

--- a/app/globals.js
+++ b/app/globals.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { TRIAGE, CONSENT, OUTCOME, ACTION_NEEDED, ACTION_TAKEN } from './enums.js'
+import { TRIAGE, CONSENT, OUTCOME, ACTION_NEEDED, ACTION_TAKEN, REFUSAL_REASON } from './enums.js'
 
 export default () => {
   const globals = {
@@ -7,7 +7,8 @@ export default () => {
     CONSENT,
     OUTCOME,
     ACTION_NEEDED,
-    ACTION_TAKEN
+    ACTION_TAKEN,
+    REFUSAL_REASON
   }
 
   /**

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -5,6 +5,8 @@ import { DateTime } from 'luxon'
 
 export default (router) => {
   router.all([
+    '/triage-consent/:campaignId/:nhsNumber',
+    '/triage-consent/:campaignId/:nhsNumber/:view',
     '/consent/:campaignId/:nhsNumber',
     '/consent/:campaignId/:nhsNumber/:view'
   ], (req, res, next) => {
@@ -13,13 +15,28 @@ export default (router) => {
 
     res.locals.campaign = campaign
     res.locals.child = campaign.children.find(c => c.nhsNumber === req.params.nhsNumber)
-    res.locals.paths = wizard(req, res)
     res.locals.base = `consent.${campaign.id}.${req.params.nhsNumber}.`
+    next()
+  })
 
+  router.all([
+    '/triage-consent/:campaignId/:nhsNumber',
+    '/triage-consent/:campaignId/:nhsNumber/:view'
+  ], (req, res, next) => {
+    res.locals.paths = wizard(req, res, true)
+    next()
+  })
+
+  router.all([
+    '/consent/:campaignId/:nhsNumber',
+    '/consent/:campaignId/:nhsNumber/:view'
+  ], (req, res, next) => {
+    res.locals.paths = wizard(req, res, false)
     next()
   })
 
   router.post([
+    '/triage-consent/:campaignId/:nhsNumber/health-questions',
     '/consent/:campaignId/:nhsNumber/health-questions'
   ], (req, res, next) => {
     const child = res.locals.child
@@ -53,6 +70,7 @@ export default (router) => {
 
   // Copy consent values to the child object
   router.post([
+    '/triage-consent/:campaignId/:nhsNumber/confirm',
     '/consent/:campaignId/:nhsNumber/confirm'
   ], (req, res, next) => {
     const child = res.locals.child
@@ -86,6 +104,7 @@ export default (router) => {
   })
 
   router.all([
+    '/triage-consent/:campaignId/:nhsNumber/details',
     '/consent/:campaignId/:nhsNumber/details'
   ], (req, res, next) => {
     // set the medical health question options for the summary list
@@ -107,18 +126,22 @@ export default (router) => {
   })
 
   router.get([
+    '/triage-consent/:campaignId/:nhsNumber',
     '/consent/:campaignId/:nhsNumber'
   ], (_req, res) => {
     res.render('consent/index')
   })
 
   router.get([
+    '/triage-consent/:campaignId/:nhsNumber/:view',
     '/consent/:campaignId/:nhsNumber/:view'
   ], (req, res) => {
     res.render(`consent/${req.params.view}`)
   })
 
   router.post([
+    '/triage-consent/:campaignId/:nhsNumber',
+    '/triage-consent/:campaignId/:nhsNumber/:view',
     '/consent/:campaignId/:nhsNumber',
     '/consent/:campaignId/:nhsNumber/:view'
   ], (_req, res) => {

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -99,6 +99,7 @@ export default (router) => {
     }
 
     if (child.consent.refused) {
+      child.consent.reason = consentData['no-consent-reason']
       child.actionTaken = 'Do not vaccinate'
       child.actionNeeded = ACTION_NEEDED.CHECK_REFUSAL
     }

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -1,6 +1,6 @@
 import wizard from '../wizards/consent.js'
 import _ from 'lodash'
-import { CONSENT } from '../enums.js'
+import { CONSENT, ACTION_NEEDED } from '../enums.js'
 import { DateTime } from 'luxon'
 
 export default (router) => {
@@ -100,6 +100,7 @@ export default (router) => {
 
     if (child.consent.refused) {
       child.actionTaken = 'Do not vaccinate'
+      child.actionNeeded = ACTION_NEEDED.CHECK_REFUSAL
     }
 
     if (gillickCompetent || assessedAsNotGillickCompetent) {

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -23,6 +23,7 @@ export default (router) => {
     '/triage-consent/:campaignId/:nhsNumber',
     '/triage-consent/:campaignId/:nhsNumber/:view'
   ], (req, res, next) => {
+    res.locals.isTriage = true
     res.locals.paths = wizard(req, res, true)
     next()
   })
@@ -85,9 +86,21 @@ export default (router) => {
     child.consent.text = consentData.consent
     child.consent.consented = consentData.consent === CONSENT.GIVEN
     child.consent.refused = consentData.consent === CONSENT.REFUSED
-    child.consent.responded = !consentData.consent === CONSENT.UNKNOWN
+    child.consent.responded = consentData.consent !== CONSENT.UNKNOWN
     child.consentedDate = DateTime.local().toISODate()
     child.consentedMethod = 'Telephone'
+
+    if (child.consent.consented) {
+      child.actionNeeded = 'Vaccinate'
+      child.actionTaken = null
+      if (res.locals.isTriage) {
+        child.triageCompleted = true
+      }
+    }
+
+    if (child.consent.refused) {
+      child.actionTaken = 'Do not vaccinate'
+    }
 
     if (gillickCompetent || assessedAsNotGillickCompetent) {
       next()

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -39,7 +39,7 @@
   <p>No response yet</p>
 
   <p class="nhsuk-u-margin-bottom-0">
-    <a href="#" class="nhsuk-button nhsuk-u-margin-bottom-2">Add consent</a>
+    <a href="/triage-consent/{{ campaign.id }}/{{ child.nhsNumber }}" class="nhsuk-button nhsuk-u-margin-bottom-2">Get consent</a>
   </p>
 {% endset %}
 

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -15,7 +15,7 @@
         },
         {
           key: "Reason for refusal",
-          value: "Personal choice"
+          value: child.consent.reason or "Personal choice"
         } if not consented,
         {
           key: child.parentOrGuardian.relationship,

--- a/app/views/consent/confirm.html
+++ b/app/views/consent/confirm.html
@@ -2,6 +2,7 @@
 {% set title = "Check and confirm answers" %}
 {% set buttonText = "Confirm" %}
 {% set consented = d(base + "consent") == CONSENT.GIVEN %}
+{% set refused = d(base + "consent") == CONSENT.REFUSED %}
 {% set isGillickCompetent = d(base + "gillick-competent") === 'Yes' %}
 
 {% block form %}
@@ -28,7 +29,12 @@
             key: 'Consent',
             value: d(base + "consent"),
             href: '#'
-          },
+          } if consented or refused,
+          {
+            key: 'Consent',
+            value: 'No response',
+            href: '#'
+          } if not (consented or refused),
           {
             key: 'For',
             value: child.fullName
@@ -46,7 +52,7 @@
               html: d(base + "no-consent-reason")
             },
             href: '#'
-          } if not consented
+          } if refused
         ])
       }) }}
     </div>

--- a/app/views/consent/why-not-consenting.html
+++ b/app/views/consent/why-not-consenting.html
@@ -21,16 +21,16 @@
       }
     },
     items: [
-      { text: 'Vaccine contains gelatine from pigs' } if campaign.isFlu,
-      { text: 'Vaccine already received' },
-      { text: 'Vaccine will be given elsewhere' },
-      { text: 'Medical reasons' },
-      { text: 'Personal choice' },
+      { text: REFUSAL_REASON.GELATINE } if campaign.isFlu,
+      { text: REFUSAL_REASON.ALREADY_GIVEN },
+      { text: REFUSAL_REASON.GETTING_ELSEWHERE },
+      { text: REFUSAL_REASON.MEDICAL },
+      { text: REFUSAL_REASON.PERSONAL },
       {
         divider: 'or'
       },
       {
-        text: 'Other',
+        text: REFUSAL_REASON.OTHER,
         conditional: {
           html: other
         }

--- a/app/wizards/consent.js
+++ b/app/wizards/consent.js
@@ -48,7 +48,7 @@ export default (req, res, isTriage) => {
     [`/campaign/${campaignId}/child/${nhsNumber}?gillick`]: {},
     [`${basePath}/pre-gillick`]: {},
     [`${basePath}/gillick`]: {
-      [`${basePath}/consent`]: {
+      [`${basePath}/consent?gillick`]: {
         data: `${baseData}.gillick-competent`,
         value: 'Yes'
       },
@@ -60,7 +60,7 @@ export default (req, res, isTriage) => {
         return true
       }
     },
-    [`${basePath}/consent`]: {
+    [`${basePath}/consent?gillick`]: {
       [`${basePath}/health-questions`]: {
         data: `${baseData}.consent`,
         value: CONSENT.GIVEN

--- a/app/wizards/consent.js
+++ b/app/wizards/consent.js
@@ -1,14 +1,16 @@
 import { wizard } from 'nhsuk-prototype-rig'
 import { CONSENT, ACTION_TAKEN } from '../enums.js'
 
-export default (req, res) => {
+export default (req, res, isTriage) => {
   const nhsNumber = req.params.nhsNumber
   const campaignId = req.params.campaignId
-  const basePath = `/consent/${campaignId}/${nhsNumber}`
+  const triagePath = isTriage ? 'triage-consent' : 'consent'
+  const childPath = isTriage ? 'child-triage' : 'child'
+  const basePath = `/${triagePath}/${campaignId}/${nhsNumber}`
   const baseData = `consent.${campaignId}.${nhsNumber}`
 
   const journey = {
-    [`/campaign/${campaignId}/child/${nhsNumber}`]: {},
+    [`/campaign/${campaignId}/${childPath}/${nhsNumber}`]: {},
     [basePath]: {},
     [`${basePath}/consent`]: {
       [`${basePath}/health-questions`]: {
@@ -27,6 +29,9 @@ export default (req, res) => {
       [`${basePath}/confirm`]: true
     },
     [`${basePath}/confirm`]: {
+      [`/campaign/${campaignId}/child-triage/${nhsNumber}`]: () => {
+        return isTriage
+      },
       [`/campaign/${campaignId}/child/${nhsNumber}`]: {
         data: `${baseData}.consent`,
         excludedValue: CONSENT.GIVEN


### PR DESCRIPTION
- Allow capturing of consent from the child page on triage
- The journey ends after confirmation
- Users are currently returned to the child page, this might need to be the children list/tab
- If there is no response, this is essentially a no-op
- Refusals go into "Do not vaccinate" not "Check refusal"
- Permission given goes into "Vaccinate" in the "No triage needed" tab
- This design does not support more complex cases where a follow up triage might be needed

https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/319055/93ba27c4-8d21-432e-9b10-571fa4c88df3

