### PR TITLE
Allow setting triage status (and notes) when getting consent

### DIFF
--- a/app/enums.js
+++ b/app/enums.js
@@ -18,7 +18,8 @@ export const ACTION_TAKEN = {
 export const TRIAGE_REASON = {
   HAS_NOTES: 'Notes need triage',
   INCONSISTENT_CONSENT: 'Conflicting consent',
-  CHECK_CONSENTER: 'Check parental responsibility'
+  CHECK_CONSENTER: 'Check parental responsibility',
+  NURSE_REQUESTED: 'Nurse requested'
 }
 
 export const TRIAGE = {

--- a/app/views/campaign/child-triage.html
+++ b/app/views/campaign/child-triage.html
@@ -53,36 +53,8 @@
                     </ul>
                   {% endif %}
 
-                  {{ textarea({
-                    label: {
-                      text: "Triage notes"
-                    },
-                    rows: 5,
-                    classes: "nhsuk-u-margin-bottom-0",
-                    decorate: ["triage", campaign.id, child.nhsNumber, "notes"]
-                  }) }}
-
-                  {{ radios({
-                    fieldset: {
-                      legend: {
-                        text: "Triage status"
-                      }
-                    },
-                    classes: "nhsuk-u-margin-bottom-0",
-                    items: [
-                      {
-                        text: TRIAGE.READY
-                      },
-                      {
-                        text: TRIAGE.DO_NOT_VACCINATE
-                      },
-                      {
-                        text: 'Keep in triage',
-                        value: TRIAGE.NEEDS_FOLLOW_UP
-                      }
-                    ],
-                    decorate: ["triage", campaign.id, child.nhsNumber, "status"]
-                  }) }}
+                  {% set showKeepInTriage = true %}
+                  {% include 'campaign/child/_triage-fields.html' %}
 
                   {{ button({
                     text: "Save triage"

--- a/app/views/campaign/child/_details.html
+++ b/app/views/campaign/child/_details.html
@@ -57,7 +57,7 @@
           value: {
             html: child.parentOrGuardian.fullName + ( parentContactDetailsHtml if responded )
           }
-        } if not triaging
+        } if child.parentOrGuardian.relationship and not triaging
       ])
     }) }}
   </div>

--- a/app/views/campaign/child/_triage-fields.html
+++ b/app/views/campaign/child/_triage-fields.html
@@ -1,0 +1,30 @@
+{{ textarea({
+  label: {
+    text: "Triage notes"
+  },
+  rows: 5,
+  classes: "nhsuk-u-margin-bottom-0",
+  decorate: ["triage", campaign.id, child.nhsNumber, "notes"]
+}) }}
+
+{{ radios({
+  fieldset: {
+    legend: {
+      text: "Triage status"
+    }
+  },
+  classes: "nhsuk-u-margin-bottom-0",
+  items: [
+    {
+      text: TRIAGE.READY
+    },
+    {
+      text: TRIAGE.DO_NOT_VACCINATE
+    },
+    {
+      text: 'Keep in triage',
+      value: TRIAGE.NEEDS_FOLLOW_UP
+    } if showKeepInTriage
+  ],
+  decorate: ["triage", campaign.id, child.nhsNumber, "status"]
+}) }}

--- a/app/views/consent/confirm.html
+++ b/app/views/consent/confirm.html
@@ -63,7 +63,34 @@
     <div class="nhsuk-u-margin-top-4">
       {% set consentJourney = true %}
       {% include "campaign/child/_health-notes-triage.html" %}
-      TODO: TRIAGE NOTES DO NOT SHOW YET
+    </div>
+
+    <div class="nhsuk-card nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
+      <div class="nhsuk-card__content">
+        <h2 class="nhsuk-heading-m">Triage</h2>
+        {% set triageNotes = d("triage." + campaign.id + "." + child.nhsNumber + ".notes") or 'No notes' %}
+        {% set triageStatus = d("triage." + campaign.id + "." + child.nhsNumber + ".status") or 'Vaccinate' %}
+
+        {% if triageStatus === TRIAGE.NEEDS_FOLLOW_UP %}
+          {% set triageStatus = 'Keep in triage' %}
+        {% endif %}
+
+        {{ govukSummaryList({
+          classes: "app-u-frutiger app-summary-list--no-bottom-border",
+          rows: decorateRows([
+            {
+              key: 'Triage notes',
+              value: triageNotes,
+              href: '#'
+            },
+            {
+              key: 'Status',
+              value: triageStatus,
+              href: '#'
+            }
+          ])
+        }) }}
+      </div>
     </div>
   {% endif %}
 {% endblock %}

--- a/app/views/consent/health-questions.html
+++ b/app/views/consent/health-questions.html
@@ -36,12 +36,7 @@
     }) }}
   {% endfor %}
 
-  {{ textarea({
-    label: {
-      text: "Triage notes (optional)"
-    },
-    rows: 5,
-    classes: "nhsuk-u-margin-bottom-0",
-    decorate: ["triage", campaign.id, child.nhsNumber, "notes"]
-  }) }}
+  <h2 class="nhsuk-heading-m nhsuk-u-margin-top-8">Triage</h2>
+  {% set showKeepInTriage = isTriage %}
+  {% include "campaign/child/_triage-fields.html" %}
 {% endblock %}


### PR DESCRIPTION

https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/319055/5e46f966-9292-400c-afa8-d4c5ef564a15

- Add triage status to health questions page
- Show triage notes and status on confirm page
- Set triage status action needed and triage statuses based on response

Covers the scenarios:
- Consent given, but health questions mean "do not vaccinate" or "keep in triage"

During the record flow we still ask "was the vaccine given" and capture a reason why not. This is MVP and we might need to refine this journey, maybe shortcutting those last questions altogether.