### PR TITLE
Verbal consent: show triage notes on confirm page

### DIFF
--- a/app/views/campaign/child/_health-notes-triage.html
+++ b/app/views/campaign/child/_health-notes-triage.html
@@ -19,6 +19,17 @@
       </p>
     </div>
   {% endfor %}
+  {% if consentJourney and triageRecord.notes %}
+    <h3 class="nhsuk-heading-xs nhsuk-u-margin-top-8 nhsuk-u-margin-bottom-0">
+      Triage notes
+    </h3>
+
+    <div class="nhsuk-u-margin-top-2">
+      <p class="nhsuk-u-margin-bottom-0">
+        {{ triageRecord.notes }}
+      </p>
+    </div>
+  {% endif %}
 {% endset %}
 
 {{ card({

--- a/app/views/consent/confirm.html
+++ b/app/views/consent/confirm.html
@@ -62,8 +62,8 @@
   {% if consented %}
     <div class="nhsuk-u-margin-top-4">
       {% set consentJourney = true %}
+      {% set triageRecord = d('triage.' + campaign.id + '.' + child.nhsNumber) %}
       {% include "campaign/child/_health-notes-triage.html" %}
-      TODO: TRIAGE NOTES DO NOT SHOW YET
     </div>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Before

<img width="816" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/23801/9e78abdf-05d0-497f-a2db-2a12859fe3ad">

## After: triage notes not provided

<img width="803" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/23801/85496569-a0b1-416b-8438-15daafe766e3">

## After: triage notes provided

<img width="837" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/23801/d9a8f18d-9506-41cb-a947-240568bce4d3">
