### PR TITLE
Allow triage notes even when consent hasn't been provided

### DIFF
--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -49,3 +49,25 @@
   headingClasses: "nhsuk-heading-m",
   description: consentHtml if child.consent.responded else noResponseHtml
 }) }}
+
+{% if not child.consent.responded %}
+  <div class="nhsuk-card">
+    <div class="nhsuk-card__content">
+      <h2 class="nhsuk-heading-m">Triage</h2>
+
+      {{ textarea({
+        label: {
+          text: "Triage notes"
+        },
+        rows: 5,
+        classes: "nhsuk-u-margin-bottom-0",
+        decorate: ["triage", campaign.id, child.nhsNumber, "notes"]
+      }) }}
+
+      {{ button({
+        text: "Add notes",
+        classes: "nhsuk-button--secondary"
+      }) }}
+    </div>
+  </div>
+{% endif %}


### PR DESCRIPTION
This would allow SAIS nurses to document failed attempts to get verbal consent.

## Before

<img width="522" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/23801/5177a504-acc5-4e36-8b98-a5b11a4813a4">

## After

<img width="539" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/23801/87167e6b-548e-47dd-9fd8-ade6354d7d51">
