### PR TITLE
Tidy up how consent is modelled in the prototype generated data

### DIFF
--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -72,14 +72,6 @@ export default (options) => {
     handleInProgressTriage(c)
   }
 
-  c.consentedMethod = faker.helpers.arrayElement([
-    ...Array(5).fill('Website'),
-    'Text message',
-    'Telephone',
-    'In person',
-    'Paper'
-  ])
-
   c.parentOrGuardian = c.consent.responded ? parent(faker, c.lastName) : {}
   return c
 }

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -8,7 +8,6 @@ import healthQuestions from './health-questions.js'
 import { dateOfBirth, yearGroup, age } from './age.js'
 import triageNeeded from './triage-needed.js'
 import { fakerEN_GB as faker } from '@faker-js/faker'
-import { DateTime } from 'luxon'
 import { OUTCOME, CONSENT, ACTION_NEEDED } from '../enums.js'
 
 const preferredName = (child) => {
@@ -73,8 +72,6 @@ export default (options) => {
     handleInProgressTriage(c)
   }
 
-  const days = faker.number.int({ min: 10, max: 35 })
-  c.consentedDate = DateTime.local().minus({ days }).toISODate()
   c.consentedMethod = faker.helpers.arrayElement([
     ...Array(5).fill('Website'),
     'Text message',

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -1,5 +1,4 @@
 import person from './person.js'
-import parent from './parent.js'
 import address from './address.js'
 import consent from './consent.js'
 import triageStatus from './triage-status.js'
@@ -58,7 +57,7 @@ export default (options) => {
   c.dob = dateOfBirth(faker, options)
   c.age = age(c.dob)
   c.yearGroup = yearGroup(c.dob)
-  c.consent = consent(faker, options.type)
+  c.consent = consent(faker, options.type, c.lastName)
   c.outcome = OUTCOME.NO_OUTCOME_YET
 
   setActions(c, c.consent[options.type])
@@ -72,6 +71,5 @@ export default (options) => {
     handleInProgressTriage(c)
   }
 
-  c.parentOrGuardian = c.consent.responded ? parent(faker, c.lastName) : {}
   return c
 }

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -57,6 +57,14 @@ export default (faker, type) => {
 
   const days = faker.number.int({ min: 10, max: 35 })
 
+  const method = faker.helpers.arrayElement([
+    ...Array(5).fill('Website'),
+    'Text message',
+    'Telephone',
+    'In person',
+    'Paper'
+  ])
+
   return {
     [type]: r,
     text: r,
@@ -64,6 +72,7 @@ export default (faker, type) => {
     consented: r === CONSENT.GIVEN,
     responded: r !== CONSENT.UNKNOWN,
     date: DateTime.local().minus({ days }).toISODate(),
+    method: method,
     reason
   }
 }

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -1,4 +1,5 @@
 import { CONSENT, REFUSAL_REASON } from '../enums.js'
+import { DateTime } from 'luxon'
 
 export default (faker, type) => {
   if (type === '3-in-1 and MenACWY') {
@@ -54,12 +55,15 @@ export default (faker, type) => {
     reason = faker.helpers.arrayElement(availableReasons)
   }
 
+  const days = faker.number.int({ min: 10, max: 35 })
+
   return {
     [type]: r,
     text: r,
     refused: r === CONSENT.REFUSED,
     consented: r === CONSENT.GIVEN,
     responded: r !== CONSENT.UNKNOWN,
+    date: DateTime.local().minus({ days }).toISODate(),
     reason
   }
 }

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -1,7 +1,8 @@
 import { CONSENT, REFUSAL_REASON } from '../enums.js'
 import { DateTime } from 'luxon'
+import parent from './parent.js'
 
-export default (faker, type) => {
+export default (faker, type, childsLastName) => {
   if (type === '3-in-1 and MenACWY') {
     const yes = {
       '3-in-1': CONSENT.GIVEN,
@@ -65,6 +66,8 @@ export default (faker, type) => {
     'Paper'
   ])
 
+  const parentOrGuardian = r !== CONSENT.UNKNOWN ? parent(faker, childsLastName) : {}
+
   return {
     [type]: r,
     text: r,
@@ -73,6 +76,7 @@ export default (faker, type) => {
     responded: r !== CONSENT.UNKNOWN,
     date: DateTime.local().minus({ days }).toISODate(),
     method: method,
+    parentOrGuardian: parentOrGuardian,
     reason
   }
 }

--- a/app/generators/triage-needed.js
+++ b/app/generators/triage-needed.js
@@ -5,7 +5,7 @@ export default (faker, child) => {
   child.needsTriage = false
   if (!child.consent.consented) return
 
-  if (child.parentOrGuardian && child.parentOrGuardian.queryRelationship) {
+  if (child.consent.parentOrGuardian && child.consent.parentOrGuardian.queryRelationship) {
     child.needsTriage = true
     child.actionNeeded = ACTION_NEEDED.TRIAGE
     reasons.push(TRIAGE_REASON.CHECK_CONSENTER)

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -125,9 +125,9 @@ export default (router) => {
     if (gillickCompetent || assessedAsNotGillickCompetent) {
       next()
     } else {
-      child.parentOrGuardian.fullName = consentData.parent.name
-      child.parentOrGuardian.telephone = consentData.parent.telephone
-      child.parentOrGuardian.relationship =
+      child.consent.parentOrGuardian.fullName = consentData.parent.name
+      child.consent.parentOrGuardian.telephone = consentData.parent.telephone
+      child.consent.parentOrGuardian.relationship =
         (consentData.parent.relationship === 'Other' && consentData.parent['relationship-other'])
           ? consentData.parent['relationship-other']
           : consentData.parent.relationship

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -88,7 +88,7 @@ export default (router) => {
     child.consent.refused = consentData.consent === CONSENT.REFUSED
     child.consent.responded = consentData.consent !== CONSENT.UNKNOWN
     child.consent.date = DateTime.local().toISODate()
-    child.consentedMethod = 'Telephone'
+    child.consent.method = 'Telephone'
 
     if (child.consent.consented && triageData && triageData.status) {
       child.triageStatus = triageData.status

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -87,7 +87,7 @@ export default (router) => {
     child.consent.consented = consentData.consent === CONSENT.GIVEN
     child.consent.refused = consentData.consent === CONSENT.REFUSED
     child.consent.responded = consentData.consent !== CONSENT.UNKNOWN
-    child.consentedDate = DateTime.local().toISODate()
+    child.consent.date = DateTime.local().toISODate()
     child.consentedMethod = 'Telephone'
 
     if (child.consent.consented && triageData && triageData.status) {

--- a/app/views/campaign/child/_consent-banner-3-in-1.html
+++ b/app/views/campaign/child/_consent-banner-3-in-1.html
@@ -8,13 +8,13 @@
   {% if child.consent['men-acwy'] == CONSENT.GIVEN %}
   <div class="app-consent-banner app-consent-banner--green nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-1">
     <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-0">
-      MenACWY consent given by {{ child.parentOrGuardian.relationship | lower }}
+      MenACWY consent given by {{ child.consent.parentOrGuardian.relationship | lower }}
     </h2>
   </div>
   {% else %}
   <div class="app-consent-banner app-consent-banner--red nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-1">
     <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-0">
-      MenACWY consent refused by {{ child.parentOrGuardian.relationship | lower }}
+      MenACWY consent refused by {{ child.consent.parentOrGuardian.relationship | lower }}
     </h2>
   </div>
   {% endif %}
@@ -22,13 +22,13 @@
   {% if child.consent['3-in-1'] == CONSENT.GIVEN %}
   <div class="app-consent-banner app-consent-banner--green nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4">
     <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-0">
-      3 in 1 consent given by {{ child.parentOrGuardian.relationship | lower }}
+      3 in 1 consent given by {{ child.consent.parentOrGuardian.relationship | lower }}
     </h2>
   </div>
   {% else %}
   <div class="app-consent-banner app-consent-banner--red nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-6">
     <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-0">
-      3 in 1 consent refused by {{ child.parentOrGuardian.relationship | lower }}
+      3 in 1 consent refused by {{ child.consent.parentOrGuardian.relationship | lower }}
     </h2>
   </div>
   {% endif %}

--- a/app/views/campaign/child/_consent-banner.html
+++ b/app/views/campaign/child/_consent-banner.html
@@ -2,7 +2,7 @@
 {% if consent == CONSENT.REFUSED %}
   {% set color = 'orange' %}
   {% set text %}
-    Their {{ child.parentOrGuardian.relationship | lower }} has refused to give consent
+    Their {{ child.consent.parentOrGuardian.relationship | lower }} has refused to give consent
   {% endset %}
   {% set action = ACTION_NEEDED.CHECK_REFUSAL %}
 {% elif consent == CONSENT.UNKNOWN %}

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -25,7 +25,7 @@
         },
         {
           key: "Date",
-          value: child.consentedDate | govukDate
+          value: child.consent.date | govukDate
         },
         {
           key: "Type of consent",

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -1,7 +1,7 @@
 {% set parentContactDetailsHtml %}
   <div class="nhsuk-u-margin-top-2 nhsuk-u-font-size-16">
-    Telephone: {{ child.parentOrGuardian.telephone }}<br />
-    Email: {{ child.parentOrGuardian.email }}
+    Telephone: {{ child.consent.parentOrGuardian.telephone }}<br />
+    Email: {{ child.consent.parentOrGuardian.email }}
   </div>
 {% endset %}
 
@@ -11,16 +11,16 @@
       rows: decorateRows([
         {
           key: "Given by" if consented else "Refused by",
-          value: child.parentOrGuardian.relationship
+          value: child.consent.parentOrGuardian.relationship
         },
         {
           key: "Reason for refusal",
           value: child.consent.reason or "Personal choice"
         } if not consented,
         {
-          key: child.parentOrGuardian.relationship,
+          key: child.consent.parentOrGuardian.relationship,
           value: {
-            html: child.parentOrGuardian.fullName + ( parentContactDetailsHtml if responded )
+            html: child.consent.parentOrGuardian.fullName + ( parentContactDetailsHtml if responded )
           }
         },
         {

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -29,7 +29,7 @@
         },
         {
           key: "Type of consent",
-          value: child.consentedMethod
+          value: child.consent.method
         }
       ])
     }) }}

--- a/app/views/campaign/child/_details.html
+++ b/app/views/campaign/child/_details.html
@@ -5,8 +5,8 @@
     </h2>
     {% set parentContactDetailsHtml %}
       <div class="nhsuk-u-margin-top-2 nhsuk-u-font-size-16">
-        Telephone: {{ child.parentOrGuardian.telephone }}<br />
-        Email: {{ child.parentOrGuardian.email }}
+        Telephone: {{ child.consent.parentOrGuardian.telephone }}<br />
+        Email: {{ child.consent.parentOrGuardian.email }}
       </div>
     {% endset %}
 
@@ -53,11 +53,11 @@
           }
         } if responded,
         {
-          key: child.parentOrGuardian.relationship,
+          key: child.consent.parentOrGuardian.relationship,
           value: {
-            html: child.parentOrGuardian.fullName + ( parentContactDetailsHtml if responded )
+            html: child.consent.parentOrGuardian.fullName + ( parentContactDetailsHtml if responded )
           }
-        } if child.parentOrGuardian.relationship and not triaging
+        } if child.consent.parentOrGuardian.relationship and not triaging
       ])
     }) }}
   </div>

--- a/app/views/campaign/child/_outcome-banner.html
+++ b/app/views/campaign/child/_outcome-banner.html
@@ -16,12 +16,12 @@
     {% if isGillickCompetent %}
       The child was assessed as Gillick competent and they gave consent.
     {% else %}
-      Their {{ child.parentOrGuardian.relationship | lower }} gave consent
+      Their {{ child.consent.parentOrGuardian.relationship | lower }} gave consent
     {% endif %}
   {% endset %}
 {% elif consent == 'Refused' %}
   {% set consentText %}
-    Their {{ child.parentOrGuardian.relationship | lower }} refused to give consent
+    Their {{ child.consent.parentOrGuardian.relationship | lower }} refused to give consent
   {% endset %}
 {% elif consent == 'Unknown' %}
   {% set consentText %}


### PR DESCRIPTION
Before this change, the following 3 fields sat on the `child` record, not nested under `child.consent`:

* `child.consentedDate`
* `child.consentedMethod`
* `child.parentOrGuardian`

In order to support multiple consents further down the line, these should sit together with the other consent fields.