### PR TITLE
Revert rollup-plugin-scss to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "npm-run-all": "^4.1.5",
         "rollup": "^3.27.0",
         "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-scss": "4.0.0",
+        "rollup-plugin-scss": "3.0.0",
         "sass": "^1.64.1"
       },
       "devDependencies": {
@@ -5977,14 +5977,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/nhsuk-prototype-rig/node_modules/rollup-plugin-scss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
-      "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
-      "dependencies": {
-        "rollup-pluginutils": "^2.3.3"
-      }
-    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -7773,9 +7765,9 @@
       }
     },
     "node_modules/rollup-plugin-scss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-4.0.0.tgz",
-      "integrity": "sha512-wxasNXDYC2m+fDxCMgK00WebVWYmeFvShyNABmjvSJZ6D1/SepwqFeaMFMQromveI79gfvb64yJjiZZxSZxEIA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
+      "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
       "dependencies": {
         "rollup-pluginutils": "^2.3.3"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "npm-run-all": "^4.1.5",
     "rollup": "^3.27.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-scss": "4.0.0",
+    "rollup-plugin-scss": "3.0.0",
     "sass": "^1.64.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This bump seems to break CSS generation on Heroku.