### PR TITLE
Add ability to record half dose of flu vaccine

### DIFF
--- a/app/views/campaign/child/_action-vaccinate-options.html
+++ b/app/views/campaign/child/_action-vaccinate-options.html
@@ -13,18 +13,23 @@
 {{ radios({
   fieldset: {
     legend: {
-      text: "Did they get the " + (campaign.type | lower if campaign.type == 'Flu' else campaign.type) + " vaccine?",
+      text: "Did they get the " + ("flu" if campaign.isFlu else campaign.type) + " vaccine?",
       isPageHeading: true,
       classes: "nhsuk-fieldset__legend--l"
     }
   } if consentJourney,
   items: [{
-    text: "Yes, they got the " + (campaign.type | lower if campaign.type == 'Flu' else campaign.type) + " vaccine",
+    text:
+      "Yes, they got the full dose" if campaign.isFlu else
+      "Yes, they got the " + campaign.type + " vaccine",
     value: "Yes",
     conditional: {
       html: where
     } if not campaign.isFlu
   }, {
+    text: "Yes, they got half a dose",
+    value: "Half"
+  } if campaign.isFlu, {
     text: "No, they did not get it",
     value: "No"
   }],

--- a/app/views/vaccination/_single-vaccine-details.html
+++ b/app/views/vaccination/_single-vaccine-details.html
@@ -12,8 +12,6 @@
 {% set vaccineGiven = vaccinationRecord['given'] !== 'No' %}
 {% set basePath = rootPath + campaign.id + '/' + child.nhsNumber %}
 
-{{ vaccine.summary }}
-
 {{ govukSummaryList({
   classes: "app-u-frutiger app-summary-list--no-bottom-border",
   rows: decorateRows([
@@ -31,6 +29,11 @@
       href: "#"
     } if type == "HPV",
     {
+      key: "Dose",
+      value: "Half" if vaccinationRecord.given == "Half" else "Full",
+      href: "#"
+    } if type == "Flu",
+    {
       key: "Brand",
       value: brand,
       href: "#"
@@ -43,12 +46,12 @@
     {
       key: 'Site',
       value: 'Nasal'
-    } if vaccineGiven and vaccine.isNasal,
+    } if vaccineGiven and batch.isNasal,
     {
       key: 'Site',
       value: vaccinationRecord.where,
       href: basePath + '/has-it-been-given'
-    } if vaccineGiven and not vaccine.isNasal,
+    } if vaccineGiven and not batch.isNasal,
     {
       key: 'Reason',
       value: vaccinationRecord['why-not-given'],

--- a/app/views/vaccination/has-it-been-given.html
+++ b/app/views/vaccination/has-it-been-given.html
@@ -31,12 +31,17 @@
       }
     },
     items: [{
-      text: "Yes, they had the " + type + " vaccine",
+      text:
+        "Yes, they got the full dose" if campaign.isFlu else
+        "Yes, they got the " + type + " vaccine",
       value: "Yes",
       conditional: {
         html: where
       } if campaign.vaccines[0].method == "Injection"
     }, {
+      text: "Yes, they got half a dose",
+      value: "Half"
+    } if campaign.isFlu, {
       text: "No, they did not get the vaccine",
       value: "No"
     }],


### PR DESCRIPTION
When recording a flu vaccination, provide an additional answer that lets a nurse record that only half a dose was given:

![Screenshot 2023-09-06 at 16 33 10](https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/b35a10a4-7c5a-43ea-8f4c-3792a83c278c)

Rather than use a wordier sentence for this option (for example ‘Yes, they got half a dose of the vaccine’), have added ‘Half dose’ in brackets, so its easier to identify when scanning the 3 options.

For nasal flu vaccinations, we also show the summary row for Dose as we do for other vaccinations:

![Screenshot 2023-09-06 at 16 33 30](https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/2c75c768-992d-4e88-8301-7950682a7e2c)

This says ‘Half’ if half was given, ‘Full’ if a full dose was given.