### PR TITLE
Show child’s name as heading cation on relevant flows

### DIFF
--- a/app/views/_components/heading/macro.njk
+++ b/app/views/_components/heading/macro.njk
@@ -1,0 +1,3 @@
+{% macro appHeading(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/views/_components/heading/template.njk
+++ b/app/views/_components/heading/template.njk
@@ -1,0 +1,7 @@
+{%- set size = params.size or "l" -%}
+<h1 class="nhsuk-heading-{{ size }}">
+  {%- if params.caption -%}
+  <span class="nhsuk-caption-{{ size }}">{{ params.caption }}</span>
+  {% endif -%}
+  {{- params.title -}}
+</h1>

--- a/app/views/campaign/child/_action-vaccinate-options.html
+++ b/app/views/campaign/child/_action-vaccinate-options.html
@@ -10,11 +10,12 @@
   }) }}
 {% endset %}
 
+{% set title = "Did they get the " + ("flu" if campaign.type == "Flu" else campaign.type) + " vaccine?" %}
+
 {{ radios({
   fieldset: {
     legend: {
-      text: "Did they get the " + (campaign.type | lower if campaign.type == 'Flu' else campaign.type) + " vaccine?",
-      isPageHeading: true,
+      text: appHeading({ caption: child.fullName, title: title }),
       classes: "nhsuk-fieldset__legend--l"
     }
   } if consentJourney,

--- a/app/views/consent/consent.html
+++ b/app/views/consent/consent.html
@@ -10,8 +10,7 @@
   {{ radios({
     fieldset: {
       legend: {
-        text: title,
-        isPageHeading: true,
+        text: appHeading({ caption: child.fullName, title: title }),
         classes: "nhsuk-fieldset__legend--l"
       }
     },

--- a/app/views/consent/gillick.html
+++ b/app/views/consent/gillick.html
@@ -5,8 +5,7 @@
   {{ radios({
     fieldset: {
       legend: {
-        text: title,
-        isPageHeading: true,
+        text: appHeading({ caption: child.fullName, title: title }),
         classes: "nhsuk-fieldset__legend--l"
       }
     },

--- a/app/views/consent/health-questions.html
+++ b/app/views/consent/health-questions.html
@@ -2,7 +2,7 @@
 {% set title = "Health questions" %}
 
 {% block form %}
-  <h1 class="nhsuk-heading-l">{{ title }}</h1>
+  {{ appHeading({ caption: child.fullName, title: title }) }}
 
   {% for q in child.healthQuestions.questions %}
     {% set giveDetailsHtml %}

--- a/app/views/consent/index.html
+++ b/app/views/consent/index.html
@@ -2,7 +2,7 @@
 {% set title = "Who are you trying to get consent from?" %}
 
 {% block form %}
-  <h1 class="nhsuk-heading-l">{{ title }}</h1>
+  {{ appHeading({ caption: child.fullName, title: title }) }}
 
   {{ input({
     label: {

--- a/app/views/consent/pre-gillick.html
+++ b/app/views/consent/pre-gillick.html
@@ -3,7 +3,7 @@
 {% set buttonText = "Give your assessment" %}
 
 {% block form %}
-  <h1 class="nhsuk-heading-l">{{ title }}</h1>
+  {{ appHeading({ caption: child.fullName, title: title }) }}
 
   <p>
     Can the young person tell you:

--- a/app/views/consent/why-not-consenting.html
+++ b/app/views/consent/why-not-consenting.html
@@ -16,8 +16,7 @@
     fieldset: {
       legend: {
         classes: "nhsuk-fieldset__legend--l",
-        text: title,
-        isPageHeading: true
+        text: appHeading({ caption: child.fullName, title: title })
       }
     },
     items: [

--- a/app/views/layouts/default.html
+++ b/app/views/layouts/default.html
@@ -1,4 +1,5 @@
 {% extends "template.njk" %}
+{% from "_components/heading/macro.njk" import appHeading %}
 {% from "_components/icon/macro.njk" import appIcon %}
 {% from "_components/iconTick/macro.njk" import appIconTick %}
 {% from "_components/iconCross/macro.njk" import appIconCross %}

--- a/app/views/vaccination/not-given.html
+++ b/app/views/vaccination/not-given.html
@@ -6,8 +6,7 @@
     fieldset: {
       legend: {
         classes: "nhsuk-fieldset__legend--l",
-        isPageHeading: true,
-        text: title
+        text: appHeading({ caption: child.fullName, title: title })
       }
     },
     items: [

--- a/app/views/vaccination/other-site.html
+++ b/app/views/vaccination/other-site.html
@@ -2,7 +2,7 @@
 {% set title = "Tell us how the vaccination was given" %}
 
 {% block form %}
-  <h1 class="nhsuk-heading-l">{{ title }}</h1>
+  {{ appHeading({ caption: child.fullName, title: title }) }}
 
   {{ radios({
     fieldset: {

--- a/app/views/vaccination/which-batch.html
+++ b/app/views/vaccination/which-batch.html
@@ -63,7 +63,7 @@
     fieldset: {
       legend: {
         classes: "nhsuk-fieldset__legend--l",
-        text: title
+        text: appHeading({ caption: child.fullName, title: title })
       }
     },
     items: items,


### PR DESCRIPTION
During the model office, it was noted that it’s sometimes hard to keep track of which child an action is being taken against.

We can address this by always showing the child’s name above the page title in a caption:

<img width="675" alt="Screenshot 2023-09-07 at 16 28 59" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/e917ab09-145a-445d-aa60-88c9bed43826">
