### PR TITLE
Set default font family for GOV.UK components

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 // GOV.UK Frontend options
+$govuk-font-family: "Frutiger W01", Arial, sans-serif;
 $govuk-global-styles: false;
 $govuk-new-link-styles: true;
 $govuk-assets-path: "/govuk/assets/";
@@ -53,11 +54,6 @@ $color_app-pale-blue: #ccdff1;
 
 .app-u-text-decoration-none {
   text-decoration: none !important;
-}
-
-.app-u-frutiger,
-.app-u-frutiger * {
-  font-family: "Frutiger W01", Arial, sans-serif !important
 }
 
 .app-summary-list--no-bottom-border {

--- a/app/views/campaign/_children-banner.html
+++ b/app/views/campaign/_children-banner.html
@@ -18,9 +18,8 @@
   {% endset %}
 
   {{ govukNotificationBanner({
-  html: html,
-  classes: "app-u-frutiger",
-  type: "success"
+    html: html,
+    type: "success"
   }) }}
 {% elseif success %}
   {% set html %}
@@ -43,7 +42,6 @@
 
   {{ govukNotificationBanner({
     html: html,
-    classes: "app-u-frutiger",
     type: "success"
   }) }}
 {% endif %}

--- a/app/views/campaign/child/_vaccination-recorded.html
+++ b/app/views/campaign/child/_vaccination-recorded.html
@@ -3,7 +3,7 @@
   {% set batch = data.vaccines.batches[vaccinationRecord.batch] %}
 
   {{ govukSummaryList({
-    classes: "app-u-frutiger app-summary-list--no-bottom-border  nhsuk-u-margin-bottom-0",
+    classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
     rows: decorateRows([
       {
         key: "Vaccine",

--- a/app/views/campaign/index.html
+++ b/app/views/campaign/index.html
@@ -26,7 +26,6 @@
         {% endset %}
         {{ govukNotificationBanner({
           html: html,
-          classes: "app-u-frutiger",
           type: "success"
         }) }}
       {% endif %}

--- a/app/views/campaign/new/check.html
+++ b/app/views/campaign/new/check.html
@@ -7,7 +7,7 @@
   <h1 class="nhsuk-heading-l">{{ title }}</h1>
 
   {{ govukSummaryList({
-    classes: "app-u-frutiger app-summary-list--no-bottom-border",
+    classes: "app-summary-list--no-bottom-border",
     rows: decorateRows([
       {
         key: "Type of session",

--- a/app/views/consent/confirm.html
+++ b/app/views/consent/confirm.html
@@ -23,7 +23,7 @@
     <div class="nhsuk-card__content">
       <h2 class="nhsuk-heading-m">Consent</h2>
       {{ govukSummaryList({
-        classes: "app-u-frutiger app-summary-list--no-bottom-border",
+        classes: "app-summary-list--no-bottom-border",
         rows: decorateRows([
           {
             key: "Consent",
@@ -76,7 +76,7 @@
         {% endif %}
 
         {{ govukSummaryList({
-          classes: "app-u-frutiger app-summary-list--no-bottom-border",
+          classes: "app-summary-list--no-bottom-border",
           rows: decorateRows([
             {
               key: "Triage notes",

--- a/app/views/manage-users.html
+++ b/app/views/manage-users.html
@@ -26,7 +26,6 @@
 
             {{ govukNotificationBanner({
               html: html,
-              classes: "app-u-frutiger",
               type: "success"
             }) }}
           {% endif %}

--- a/app/views/vaccination/_multiple-vaccine-details.html
+++ b/app/views/vaccination/_multiple-vaccine-details.html
@@ -2,7 +2,7 @@
 {% set 3in1VaccineGiven = "3-in-1" in vaccinationRecord["multi-given"] %}
 
 {{ govukSummaryList({
-  classes: "app-u-frutiger app-summary-list--no-bottom-border",
+  classes: "app-summary-list--no-bottom-border",
   rows: decorateRows([
     {
       key: "Child",
@@ -39,7 +39,7 @@
 
 {% if child.consent["men-acwy"] == "Yes" or menACWYVaccineGiven %}
   {{ govukSummaryList({
-    classes: "app-u-frutiger app-summary-list--no-bottom-border",
+    classes: "app-summary-list--no-bottom-border",
     rows: decorateRows([
       {
         key: "Brand",
@@ -80,7 +80,7 @@
 
 {% if child.consent["3-in-1"] == "Yes" or 3in1VaccineGiven %}
   {{ govukSummaryList({
-    classes: "app-u-frutiger app-summary-list--no-bottom-border",
+    classes: "app-summary-list--no-bottom-border",
     rows: decorateRows([
       {
         key: "Brand",

--- a/app/views/vaccination/_single-vaccine-details.html
+++ b/app/views/vaccination/_single-vaccine-details.html
@@ -15,7 +15,7 @@
 {{ vaccine.summary }}
 
 {{ govukSummaryList({
-  classes: "app-u-frutiger app-summary-list--no-bottom-border",
+  classes: "app-summary-list--no-bottom-border",
   rows: decorateRows([
     {
       key: "Child",

--- a/app/views/vaccination/confirmation.html
+++ b/app/views/vaccination/confirmation.html
@@ -13,7 +13,7 @@
   {{ govukPanel({
     titleText: title,
     html: html,
-    classes: "nhsuk-u-margin-bottom-6 app-u-frutiger"
+    classes: "nhsuk-u-margin-bottom-6"
   }) }}
 
   <h2 class="nhsuk-u-heading-m">Continue</h2>


### PR DESCRIPTION
We can set the default font family for imported GOV.UK Design System components by setting `$govuk-font-family`, as opposed to using a utility class.