### PR TITLE
Remove superfluous ‘Add notes’ panel on child details page

### DIFF
--- a/app/views/campaign/child.html
+++ b/app/views/campaign/child.html
@@ -58,27 +58,8 @@
           {% elif child.outcome == "Vaccinated" %}
             {% include "campaign/child/_vaccination-recorded.html" %}
           {% endif %}
-
-          <div class="nhsuk-card">
-            <div class="nhsuk-card__content">
-              {{ textarea({
-                label: {
-                  text: "Add notes",
-                  classes: "nhsuk-label--m nhsuk-u-margin-bottom-3"
-                },
-                rows: 5,
-                name: "notes",
-                classes: "nhsuk-u-margin-bottom-0",
-                decorate: ["vaccination", campaign.id, child.nhsNumber, "notes"]
-              }) }}
-
-              {{ button({
-                text: "Add notes",
-                classes: "nhsuk-button--secondary"
-              }) }}
-            </div>
-          </div>
         </div>
+
         <div class="nhsuk-grid-column-one-third">
           {% if campaign["available-offline"] %}
             <div id="available-offline">


### PR DESCRIPTION
There is currently an ‘Add notes’ panel that appears on the foot of a child’s record during the record phase.

However, this panel is superfluous as:

* We ask for any notes as part of the ‘Did they get the vaccine?’ flow
* Other times we want to gather notes, they can/should be taken as part of the respective flows
* Adding notes and clicking the submit button doesn’t work in the prototype, and not entirely clear how it would work either.

Removing this panel as prelude to further changes around notes, tracked in #136.