### PR TITLE
Multiple triage notes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,10 @@ $color_app-pale-blue: #ccdff1;
 @import "email";
 @import "offline";
 
+.app-u-nowrap {
+  white-space: nowrap;
+}
+
 .app-scenario {
   background: $color_nhsuk-grey-5;
 }

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -66,6 +66,8 @@ export default (options) => {
   c.seen = {}
   c.triageStatus = triageStatus(options.triageInProgress, c.consent)
   c.healthQuestions = healthQuestions(faker, options.type, c)
+  c.notes = []
+
   triageNeeded(faker, c)
   if (options.triageInProgress) {
     handleInProgressTriage(c)

--- a/app/routes/campaign.js
+++ b/app/routes/campaign.js
@@ -55,9 +55,8 @@ export default (router) => {
   router.post([
     '/campaign/:campaignId/child-triage/:nhsNumber'
   ], (req, res) => {
-    const child = res.locals.child
-    const nhsNumber = req.params.nhsNumber
-    const campaignId = req.params.campaignId
+    const { child } = res.locals
+    const { campaignId, nhsNumber } = req.params
     const triage = _.get(req.body, `triage.${campaignId}.${nhsNumber}`, {})
 
     if (triage) {
@@ -73,6 +72,18 @@ export default (router) => {
         child.actionTaken = ACTION_TAKEN.DO_NOT_VACCINATE
         child.triageCompleted = true
       }
+    }
+
+    // Update triage notes
+    if (triage.note) {
+      child.notes.push({
+        date: new Date().toISOString(),
+        note: triage.note,
+        stage: 'triage',
+        user: {
+          fullName: triage.user
+        }
+      })
     }
 
     res.redirect(`/campaign/${campaignId}/children-triage?success=${nhsNumber}&area=triage`)

--- a/app/routes/vaccination.js
+++ b/app/routes/vaccination.js
@@ -122,17 +122,30 @@ export default (router) => {
   router.post([
     '/vaccination/:campaignId/:nhsNumber/details'
   ], (req, res, next) => {
-    const vaccineGiven = res.locals.vaccinationRecord.given !== 'No'
+    const { child, vaccinationRecord } = res.locals
+    const vaccineGiven = vaccinationRecord.given !== 'No'
 
     if (vaccineGiven) {
-      res.locals.child.actionTaken = ACTION_TAKEN.VACCINATED
-      res.locals.child.outcome = 'Vaccinated'
-      res.locals.child.batch = res.locals.vaccinationRecord.batch
-      res.locals.child.seen = { text: 'Vaccinated', given: vaccineGiven }
+      child.actionTaken = ACTION_TAKEN.VACCINATED
+      child.outcome = 'Vaccinated'
+      child.batch = vaccinationRecord.batch
+      child.seen = { text: 'Vaccinated', given: vaccineGiven }
     } else {
-      res.locals.child.actionTaken = ACTION_TAKEN.COULD_NOT_VACCINATE
-      res.locals.child.outcome = 'Could not vaccinate'
-      res.locals.child.seen = { text: 'Vaccine not given', given: vaccineGiven }
+      child.actionTaken = ACTION_TAKEN.COULD_NOT_VACCINATE
+      child.outcome = 'Could not vaccinate'
+      child.seen = { text: 'Vaccine not given', given: vaccineGiven }
+    }
+
+    // Update triage notes
+    if (vaccinationRecord.note) {
+      child.notes.push({
+        date: new Date().toISOString(),
+        note: vaccinationRecord.note,
+        stage: 'vaccinate',
+        user: {
+          fullName: vaccinationRecord.user
+        }
+      })
     }
 
     res.locals.child.seen.isOffline = res.locals.isOffline

--- a/app/views/campaign/child-triage.html
+++ b/app/views/campaign/child-triage.html
@@ -37,6 +37,8 @@
           {% endif %}
 
           {% if child.consent.responded %}
+            {% include "campaign/child/_triage-notes.html" %}
+
             <div class="nhsuk-card">
               <div class="nhsuk-card__content">
                 <form method="post">
@@ -55,6 +57,7 @@
                   {% include "campaign/child/_triage-fields.html" %}
 
                   {{ button({
+                    classes: "nhsuk-u-margin-bottom-0",
                     text: "Save triage"
                   }) }}
                 </form>

--- a/app/views/campaign/child.html
+++ b/app/views/campaign/child.html
@@ -45,6 +45,7 @@
 
           {% if consented %}
             {% include "campaign/child/_medical-history.html" %}
+            {% include "campaign/child/_triage-notes.html" %}
           {% endif %}
 
           {% if child.outcome == "No outcome yet" %}

--- a/app/views/campaign/child/_triage-fields.html
+++ b/app/views/campaign/child/_triage-fields.html
@@ -1,19 +1,10 @@
-{{ textarea({
-  label: {
-    text: "Triage notes"
-  },
-  rows: 5,
-  classes: "nhsuk-u-margin-bottom-0",
-  decorate: ["triage", campaign.id, child.nhsNumber, "notes"]
-}) }}
-
 {{ radios({
   fieldset: {
     legend: {
+      classes: "nhsuk-fieldset__legend--s",
       text: "Triage status"
     }
   },
-  classes: "nhsuk-u-margin-bottom-0",
   items: [
     {
       text: TRIAGE.READY
@@ -27,4 +18,20 @@
     } if showKeepInTriage
   ],
   decorate: ["triage", campaign.id, child.nhsNumber, "status"]
+}) }}
+
+{{ textarea({
+  label: {
+    classes: "nhsuk-label--s nhsuk-u-margin-bottom-3",
+    text: "Triage note (optional)"
+  },
+  rows: 5,
+  value: "",
+  decorate: ["triage", campaign.id, child.nhsNumber, "note"]
+}) }}
+
+{{ input({
+  type: "hidden",
+  value: data.user.name,
+  decorate: ["triage", campaign.id, child.nhsNumber, "user"]
 }) }}

--- a/app/views/campaign/child/_triage-notes.html
+++ b/app/views/campaign/child/_triage-notes.html
@@ -1,0 +1,44 @@
+{% set cardDescription %}
+  {% if child.notes.length > 0 %}
+    {% set rows = [] %}
+    {% for note in child.notes %}
+      {% set _rows = rows.push([
+        {
+          html: "<p class=\"nhsuk-u-margin-0 app-u-nowrap\">" + note.date | govukDate("truncate") + "</p><p class=\"nhsuk-u-secondary-text-color nhsuk-u-margin-0\">" + note.date | govukTime + "</p>"
+        },
+        {
+          text: note.stage | capitalize
+        },
+        {
+          html: "<p class=\"nhsuk-u-margin-0\">" + note.note + "</p><p class=\"nhsuk-u-secondary-text-color nhsuk-u-margin-0\">" + note.user.fullName + "</p>"
+        }
+      ]) %}
+    {% endfor %}
+
+    {{ table({
+      tableClasses: "app-table--no-bottom-border",
+      firstCellIsHeader: false,
+      head: [
+        {
+          text: "Date"
+        },
+        {
+          text: "Action"
+        },
+        {
+          text: "Note"
+        }
+      ],
+      rows: rows
+    }) }}
+  {% else %}
+    <p>No notes added</p>
+  {% endif %}
+{% endset %}
+
+{{ card({
+  heading: "Triage notes",
+  headingLevel: "2",
+  headingClasses: "nhsuk-heading-m",
+  descriptionHtml: cardDescription
+}) }}

--- a/app/views/vaccination/details.html
+++ b/app/views/vaccination/details.html
@@ -30,9 +30,13 @@
           text: "For example, if the child had a reaction to the vaccine"
         },
         rows: 5,
-        name: "notes",
-        classes: "nhsuk-u-margin-bottom-0",
-        decorate: ["vaccination", campaign.id, child.nhsNumber, "notes"]
+        decorate: [dataLocation, campaign.id, child.nhsNumber, "note"]
+      }) }}
+
+      {{ input({
+        type: "hidden",
+        value: data.user.name,
+        decorate: [dataLocation, campaign.id, child.nhsNumber, "user"]
       }) }}
     </div>
   </div>


### PR DESCRIPTION
When performing triage, and when recording a vaccination, allow multiple triage notes to be captured. These appear in a ‘Triage notes’ table on a child’s record:

<img width="647" alt="Screenshot 2023-09-18 at 14 32 46" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/d171e946-9328-42a0-8951-341ef1143192">

Part of a refactor of capturing notes being tracked in #136.

 