### PR TITLE
Add consent log

### DIFF
--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -77,6 +77,7 @@ export default (faker, type, childsLastName) => {
     date: DateTime.local().minus({ days }).toISODate(),
     method,
     parentOrGuardian,
-    reason
+    reason,
+    log: []
   }
 }

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -74,8 +74,7 @@ export default (router) => {
     '/triage-consent/:campaignId/:nhsNumber/confirm',
     '/consent/:campaignId/:nhsNumber/confirm'
   ], (req, res, next) => {
-    const child = res.locals.child
-    const campaign = res.locals.campaign
+    const { campaign, child } = res.locals
     const campaignType = campaign.type
     const consentData = req.session.data.consent[req.params.campaignId][req.params.nhsNumber]
     const triageData = req.session.data.triage[req.params.campaignId][req.params.nhsNumber]
@@ -121,6 +120,17 @@ export default (router) => {
       child.consent.reasonDetails = consentData['no-consent-reason-details']
       child.actionTaken = 'Do not vaccinate'
       child.actionNeeded = ACTION_NEEDED.CHECK_REFUSAL
+    }
+
+    // Update consent log
+    if (consentData.note) {
+      child.consent.log.push({
+        date: new Date().toISOString(),
+        note: consentData.note,
+        user: {
+          fullName: consentData.user
+        }
+      })
     }
 
     if (gillickCompetent || assessedAsNotGillickCompetent) {

--- a/app/views/campaign/child/_action-get-consent.html
+++ b/app/views/campaign/child/_action-get-consent.html
@@ -1,5 +1,15 @@
 {% set getConsent %}
+  {% if child.consent.log.length > 0 %}
+    {% include "campaign/child/_consent-log.html" %}
+  {% endif %}
+
   {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--s",
+        text: "Are you attempting to get consent?"
+      }
+    },
     items: [{
       text: "Yes, I am contacting a parent or guardian",
       value: "Yes"
@@ -21,7 +31,7 @@
 
 <form method="post">
   {{ card({
-    heading: "Are you attempting to get consent?",
+    heading: "Consent",
     headingLevel: "2",
     headingClasses: "nhsuk-heading-m",
     description: getConsent

--- a/app/views/campaign/child/_consent-log.html
+++ b/app/views/campaign/child/_consent-log.html
@@ -1,0 +1,27 @@
+{% set rows = [] %}
+{% for item in child.consent.log %}
+  {% set _rows = rows.push([
+    {
+      html: "<p class=\"nhsuk-u-margin-0 app-u-nowrap\">" + item.date | govukDate("truncate") + "</p><p class=\"nhsuk-u-secondary-text-color nhsuk-u-margin-0\">" + item.date | govukTime + "</p>"
+    },
+    {
+      html: "<p class=\"nhsuk-u-margin-0\">" + item.note + "</p><p class=\"nhsuk-u-secondary-text-color nhsuk-u-margin-0\">" + item.user.fullName + "</p>"
+    }
+  ]) %}
+{% endfor %}
+
+{{ table({
+  caption: "Consent log",
+  captionClasses: "nhsuk-u-font-size-19",
+  tableClasses: "app-table--no-bottom-border",
+  firstCellIsHeader: false,
+  head: [
+    {
+      text: "Date"
+    },
+    {
+      text: "Note"
+    }
+  ],
+  rows: rows
+}) }}

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -38,7 +38,11 @@
 {% endset %}
 
 {% set noResponseHtml %}
-  <p>No response yet</p>
+  {% if child.consent.log.length > 0 %}
+    {% include "campaign/child/_consent-log.html" %}
+  {% else %}
+    <p>No response yet</p>
+  {% endif %}
 
   <p class="nhsuk-u-margin-bottom-0">
     <a href="/triage-consent/{{ campaign.id }}/{{ child.nhsNumber }}" class="nhsuk-button nhsuk-u-margin-bottom-2">Get consent</a>
@@ -51,28 +55,3 @@
   headingClasses: "nhsuk-heading-m",
   description: consentHtml if child.consent.responded else noResponseHtml
 }) }}
-
-{% if not child.consent.responded %}
-  <form method="post">
-    <div class="nhsuk-card">
-      <div class="nhsuk-card__content">
-        <h2 class="nhsuk-heading-m">Triage</h2>
-
-        {{ textarea({
-            label: {
-            text: "Triage notes"
-          },
-          rows: 5,
-          classes: "nhsuk-u-margin-bottom-0",
-          decorate: ["triage", campaign.id, child.nhsNumber, "notes"]
-        }) }}
-
-        {{ button({
-          text: "Add notes",
-          classes: "nhsuk-button--secondary"
-        }) }}
-      </div>
-    </div>
-  </form>
-
-{% endif %}

--- a/app/views/consent/confirm.html
+++ b/app/views/consent/confirm.html
@@ -19,10 +19,11 @@
     {% set consentRecord = d("consent." + campaign.id + "." + child.nhsNumber) %}
     {% include "campaign/child/_consent-gillick.html" %}
   {% else %}
-  <div class="nhsuk-card nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
-    <div class="nhsuk-card__content">
-      <h2 class="nhsuk-heading-m">Consent</h2>
-      {{ govukSummaryList({
+    {{ card({
+      heading: "Consent",
+      headingLevel: "2",
+      headingClasses: "nhsuk-heading-m",
+      descriptionHtml: govukSummaryList({
         classes: "app-summary-list--no-bottom-border",
         rows: decorateRows([
           {
@@ -54,9 +55,8 @@
             href: "#"
           } if refused
         ])
-      }) }}
-    </div>
-  </div>
+      })
+    }) }}
   {% endif %}
 
   {% if consented %}
@@ -89,6 +89,29 @@
               href: "#"
             }
           ])
+        }) }}
+      </div>
+    </div>
+  {% else %}
+    <div class="nhsuk-card nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-3">
+      <div class="nhsuk-card__content">
+        {{ textarea({
+          label: {
+            text: "Add notes",
+            classes: "nhsuk-label--m nhsuk-u-margin-bottom-3"
+          },
+          hint: {
+            text: "For example, unable to contact parent"
+          },
+          rows: 5,
+          value: "",
+          decorate: base + "note"
+        }) }}
+
+        {{ input({
+          type: "hidden",
+          value: data.user.name,
+          decorate: base + "user"
         }) }}
       </div>
     </div>


### PR DESCRIPTION
This PR splits out the ability to capture information relating to obtaining consent from those relating to triaging medical history.

Like triage notes, a table is shown showing any consent related notes that have been added:

* During triage:

  <img width="643" alt="Screenshot of consent log during triage." src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/8d164772-10e2-4dd9-9027-90f364feefb7">

* During record:

  <img width="645" alt="Screenshot of consent log during record." src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/9a5cb700-7abb-4566-ac1d-4009c9988a14">


Like the flow for adding triage notes, notes about consent can be added on the check answers page when completing the get consent flow. 

This still needs more refinement, but this PR adds the basic functionality and hopefully corrects some of the logic around collecting notes while attempting to obtain consent.