### PR TITLE
Only show triage reasons in consent banner before and during triage

### DIFF
--- a/app/views/campaign/child/_triage-banner.html
+++ b/app/views/campaign/child/_triage-banner.html
@@ -1,5 +1,6 @@
 {% set color = "blue" %}
 {% set heading = "Triage needed" %}
+{% set showTriageReasons = true %}
 
 {% if child.actionNeeded == ACTION_NEEDED.FOLLOW_UP %}
   {% set color = "aqua-green" %}
@@ -10,12 +11,14 @@
   {% set color = "purple" %}
   {% set heading = "Ready to vaccinate" %}
   {% set text = "Jane Doe decided that " + child.fullName + " can be vaccinated." %}
+  {% set showTriageReasons = false %}
 {% endif %}
 
 {% if child.actionTaken == ACTION_TAKEN.DO_NOT_VACCINATE %}
   {% set color = "red" %}
   {% set heading = "Do not vaccinate" %}
   {% set text = "Jane Doe decided that " + child.fullName + " should not be vaccinated." %}
+  {% set showTriageReasons = false %}
 {% endif %}
 
 {% call appConsentBanner({
@@ -23,7 +26,7 @@
   heading: heading,
   text: text
 }) %}
-{% if child.triageReasons %}
+{% if child.triageReasons and showTriageReasons %}
   <ul class="nhsuk-list">
   {% for reason in child.triageReasons %}
     <li>{{ reason }}</li>


### PR DESCRIPTION
| Before | After |
| - | - |
| ![Screenshot 2023-09-19 at 12 20 59](https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/f7c206f6-5156-4b1a-93f2-aee6702fe933) | ![Screenshot 2023-09-19 at 12 21 09](https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/564cba12-ea9c-414f-a1f9-365a65c40e19) |