### PR TITLE
Multiple consents

### DIFF
--- a/app/enums.js
+++ b/app/enums.js
@@ -33,6 +33,7 @@ export const TRIAGE = {
 export const CONSENT = {
   GIVEN: 'Given',
   REFUSED: 'Refused',
+  INCONSISTENT: 'Conflicting',
   UNKNOWN: 'Unknown',
   ONLY_MENACWY: 'Only MenACWY',
   ONLY_3_IN_1: 'Only 3-in-1'

--- a/app/generators/campaign-in-progress.js
+++ b/app/generators/campaign-in-progress.js
@@ -19,6 +19,11 @@ const setActions = (child, consent) => {
     }
   }
 
+  if (consent === CONSENT.INCONSISTENT) {
+    child.actionNeeded = ACTION_NEEDED.TRIAGE
+    child.outcome = OUTCOME.NO_OUTCOME_YET
+  }
+
   if (consent === CONSENT.UNKNOWN) {
     const attemptedToGetConsent = faker.helpers.maybe(
       () => true, { probability: 0.2 }

--- a/app/generators/campaign.js
+++ b/app/generators/campaign.js
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import getSchool from './school.js'
 import getChildren from './children.js'
 import getYearGroups from './year-groups.js'
+import getHealthQuestions from './health-questions.js'
 
 const generateRandomString = (length) => {
   length = length || 3
@@ -38,6 +39,7 @@ export default () => {
     location: school.name,
     date: DateTime.now().plus({ days: daysUntil }).toISODate() + 'T' + atTime,
     type,
+    healthQuestions: getHealthQuestions(type),
     triageInProgress,
     yearGroups: getYearGroups(type),
     school,

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -4,6 +4,7 @@ import { getDateOfBirth, getYearGroup, getAge } from './age.js'
 import getPerson from './person.js'
 import getAddress from './address.js'
 import getConsent from './consent.js'
+import getConsentResponses from './consent-responses.js'
 import getTriageStatus from './triage-status.js'
 import getGp from './gp.js'
 import getHealthAnswers from './health-answers.js'
@@ -57,6 +58,7 @@ export default (options) => {
   const { triageInProgress, type } = options
   const isChild = true
   const child = getPerson(faker, isChild)
+  const consentResponses = getConsentResponses(faker, type, child.lastName)
 
   // https://digital.nhs.uk/services/e-referral-service/document-library/synthetic-data-in-live-environments
   child.nhsNumber = faker.helpers.replaceSymbolWithNumber('999#######')
@@ -66,7 +68,8 @@ export default (options) => {
   child.dob = getDateOfBirth(faker, options)
   child.age = getAge(child.dob)
   child.yearGroup = getYearGroup(child.dob)
-  child.consent = getConsent(faker, type, child.lastName)
+  child.consentResponses = consentResponses
+  child.consent = getConsent(type, consentResponses)
   child.outcome = OUTCOME.NO_OUTCOME_YET
 
   child.actionNeeded = getActionNeeded(child.consent[type])

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -67,7 +67,9 @@ export default (options) => {
   child.age = getAge(child.dob)
   child.yearGroup = getYearGroup(child.dob)
   child.consent = getConsent(type)
-  child.consentResponses = getConsentResponses(faker, type, child)
+  child.consentResponses = getConsentResponses(faker, {
+    type, child, count: faker.number.int({ min: 1, max: 3 })
+  })
   child.outcome = OUTCOME.NO_OUTCOME_YET
 
   child.actionNeeded = getActionNeeded(child.consent[type])

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -7,7 +7,6 @@ import getConsent from './consent.js'
 import getConsentResponses from './consent-responses.js'
 import getTriageStatus from './triage-status.js'
 import getGp from './gp.js'
-import getHealthAnswers from './health-answers.js'
 import getTriageNeeded from './triage-needed.js'
 
 const preferredName = (child) => {
@@ -58,7 +57,6 @@ export default (options) => {
   const { triageInProgress, type } = options
   const isChild = true
   const child = getPerson(faker, isChild)
-  const consentResponses = getConsentResponses(faker, type, child.lastName)
 
   // https://digital.nhs.uk/services/e-referral-service/document-library/synthetic-data-in-live-environments
   child.nhsNumber = faker.helpers.replaceSymbolWithNumber('999#######')
@@ -68,8 +66,8 @@ export default (options) => {
   child.dob = getDateOfBirth(faker, options)
   child.age = getAge(child.dob)
   child.yearGroup = getYearGroup(child.dob)
-  child.consentResponses = consentResponses
-  child.consent = getConsent(type, consentResponses)
+  child.consent = getConsent(type)
+  child.consentResponses = getConsentResponses(faker, type, child)
   child.outcome = OUTCOME.NO_OUTCOME_YET
 
   child.actionNeeded = getActionNeeded(child.consent[type])
@@ -78,7 +76,6 @@ export default (options) => {
   child.seen = {}
   child.triageNotes = []
   child.triageStatus = getTriageStatus(triageInProgress, child.consent)
-  child.healthAnswers = getHealthAnswers(faker, type, child)
 
   getTriageNeeded(faker, child)
   if (triageInProgress) {

--- a/app/generators/consent-responses.js
+++ b/app/generators/consent-responses.js
@@ -1,0 +1,84 @@
+import { DateTime } from 'luxon'
+import { CONSENT, REFUSAL_REASON } from '../enums.js'
+import getParent from './parent.js'
+
+export default (faker, type, childsLastName) => {
+  if (type === '3-in-1 and MenACWY') {
+    const yes = {
+      '3-in-1': CONSENT.GIVEN,
+      'men-acwy': CONSENT.GIVEN,
+      text: CONSENT.GIVEN,
+      both: true,
+      consented: true,
+      responded: true
+    }
+    const no = {
+      '3-in-1': CONSENT.REFUSED,
+      'men-acwy': CONSENT.REFUSED,
+      text: CONSENT.REFUSED,
+      refusedBoth: true,
+      refused: true,
+      responded: true
+    }
+    const unknown = {
+      '3-in-1': CONSENT.UNKNOWN,
+      'men-acwy': CONSENT.UNKNOWN,
+      text: CONSENT.UNKNOWN,
+      unknown: true,
+      responded: false
+    }
+
+    return faker.helpers.arrayElement(
+      [
+        ...Array(5).fill(yes),
+        { '3-in-1': CONSENT.REFUSED, 'men-acwy': CONSENT.GIVEN, text: CONSENT.ONLY_MENACWY, responded: true, consented: true },
+        { '3-in-1': CONSENT.GIVEN, 'men-acwy': CONSENT.REFUSED, text: CONSENT.ONLY_3_IN_1, responded: true, consented: true },
+        ...Array(5).fill(unknown),
+        ...Array(2).fill(no)
+      ]
+    )
+  }
+
+  const consent = faker.helpers.arrayElement([
+    ...Array(10).fill(CONSENT.GIVEN),
+    ...Array(5).fill(CONSENT.UNKNOWN),
+    CONSENT.REFUSED
+  ])
+
+  let reason = null
+  let reasonDetails = null
+  if (consent === CONSENT.REFUSED) {
+    let availableReasons = Object.values(REFUSAL_REASON)
+    if (type !== 'Flu') {
+      availableReasons = availableReasons.filter(a => {
+        return a !== REFUSAL_REASON.GELATINE
+      })
+    }
+    reason = faker.helpers.arrayElement(availableReasons)
+
+    if (reason === REFUSAL_REASON.OTHER) {
+      reasonDetails = 'My family rejects vaccinations on principle.'
+    }
+  }
+
+  const days = faker.number.int({ min: 10, max: 35 })
+
+  const method = faker.helpers.arrayElement([
+    ...Array(5).fill('Website'),
+    'Text message',
+    'Telephone',
+    'In person',
+    'Paper'
+  ])
+
+  const parentOrGuardian = consent !== CONSENT.UNKNOWN ? getParent(faker, childsLastName) : {}
+
+  return [{
+    [type]: consent,
+    date: DateTime.local().minus({ days }).toISODate(),
+    method,
+    parentOrGuardian,
+    reason,
+    reasonDetails
+  }]
+}

--- a/app/generators/consent-responses.js
+++ b/app/generators/consent-responses.js
@@ -1,66 +1,18 @@
 import _ from 'lodash'
 import { DateTime } from 'luxon'
-import { CONSENT, REFUSAL_REASON } from '../enums.js'
+import { CONSENT } from '../enums.js'
+import getConsent from './consent.js'
+import getRefusal from './refusal.js'
 import getHealthAnswers from './health-answers.js'
 import getParent from './parent.js'
 
 export default (faker, { type, child, count }) => {
   const consentResponses = []
+
   for (let i = 0; i < count; i++) {
-    if (type === '3-in-1 and MenACWY') {
-      const yes = {
-        '3-in-1': CONSENT.GIVEN,
-        'men-acwy': CONSENT.GIVEN,
-        text: CONSENT.GIVEN,
-        both: true,
-        consented: true,
-        responded: true
-      }
-      const no = {
-        '3-in-1': CONSENT.REFUSED,
-        'men-acwy': CONSENT.REFUSED,
-        text: CONSENT.REFUSED,
-        refusedBoth: true,
-        refused: true,
-        responded: true
-      }
-      const unknown = {
-        '3-in-1': CONSENT.UNKNOWN,
-        'men-acwy': CONSENT.UNKNOWN,
-        text: CONSENT.UNKNOWN,
-        unknown: true,
-        responded: false
-      }
-
-      return faker.helpers.arrayElement(
-        [
-          ...Array(5).fill(yes),
-          { '3-in-1': CONSENT.REFUSED, 'men-acwy': CONSENT.GIVEN, text: CONSENT.ONLY_MENACWY, responded: true, consented: true },
-          { '3-in-1': CONSENT.GIVEN, 'men-acwy': CONSENT.REFUSED, text: CONSENT.ONLY_3_IN_1, responded: true, consented: true },
-          ...Array(5).fill(unknown),
-          ...Array(2).fill(no)
-        ]
-      )
-    }
-
-    let reason = null
-    let reasonDetails = null
-    if (child.consent === CONSENT.REFUSED) {
-      let availableReasons = Object.values(REFUSAL_REASON)
-      if (type !== 'Flu') {
-        availableReasons = availableReasons.filter(a => {
-          return a !== REFUSAL_REASON.GELATINE
-        })
-      }
-      reason = faker.helpers.arrayElement(availableReasons)
-
-      if (reason === REFUSAL_REASON.OTHER) {
-        reasonDetails = 'My family rejects vaccinations on principle.'
-      }
-    }
-
+    const consent = getConsent(type)
+    const { reason, reasonDetails } = getRefusal(type)
     const days = faker.number.int({ min: 10, max: 35 })
-
     const method = faker.helpers.arrayElement([
       ...Array(5).fill('Website'),
       'Text message',
@@ -69,16 +21,18 @@ export default (faker, { type, child, count }) => {
       'Paper'
     ])
 
-    const parentOrGuardian = child.consent !== CONSENT.UNKNOWN ? getParent(faker, child.lastName) : {}
-
     consentResponses.push({
-      [type]: child.consent,
+      [type]: consent,
       date: DateTime.local().minus({ days }).toISODate(),
       method,
-      parentOrGuardian,
-      healthAnswers: getHealthAnswers(faker, type, child),
-      ...reason && { reason },
-      ...reasonDetails && { reasonDetails }
+      parentOrGuardian: getParent(faker, child.lastName),
+      healthAnswers: (consent === CONSENT.GIVEN)
+        ? getHealthAnswers(faker, type, child)
+        : false,
+      ...(consent === CONSENT.REFUSED) && {
+        reason,
+        ...reasonDetails && { reasonDetails }
+      }
     })
   }
 

--- a/app/generators/consent-responses.js
+++ b/app/generators/consent-responses.js
@@ -1,8 +1,9 @@
 import { DateTime } from 'luxon'
 import { CONSENT, REFUSAL_REASON } from '../enums.js'
+import getHealthAnswers from './health-answers.js'
 import getParent from './parent.js'
 
-export default (faker, type, childsLastName) => {
+export default (faker, type, child) => {
   if (type === '3-in-1 and MenACWY') {
     const yes = {
       '3-in-1': CONSENT.GIVEN,
@@ -39,15 +40,9 @@ export default (faker, type, childsLastName) => {
     )
   }
 
-  const consent = faker.helpers.arrayElement([
-    ...Array(10).fill(CONSENT.GIVEN),
-    ...Array(5).fill(CONSENT.UNKNOWN),
-    CONSENT.REFUSED
-  ])
-
   let reason = null
   let reasonDetails = null
-  if (consent === CONSENT.REFUSED) {
+  if (child.consent === CONSENT.REFUSED) {
     let availableReasons = Object.values(REFUSAL_REASON)
     if (type !== 'Flu') {
       availableReasons = availableReasons.filter(a => {
@@ -71,13 +66,14 @@ export default (faker, type, childsLastName) => {
     'Paper'
   ])
 
-  const parentOrGuardian = consent !== CONSENT.UNKNOWN ? getParent(faker, childsLastName) : {}
+  const parentOrGuardian = child.consent !== CONSENT.UNKNOWN ? getParent(faker, child.lastName) : {}
 
   return [{
-    [type]: consent,
+    [type]: child.consent,
     date: DateTime.local().minus({ days }).toISODate(),
     method,
     parentOrGuardian,
+    healthAnswers: getHealthAnswers(faker, type, child),
     reason,
     reasonDetails
   }]

--- a/app/generators/consent-responses.js
+++ b/app/generators/consent-responses.js
@@ -1,80 +1,86 @@
+import _ from 'lodash'
 import { DateTime } from 'luxon'
 import { CONSENT, REFUSAL_REASON } from '../enums.js'
 import getHealthAnswers from './health-answers.js'
 import getParent from './parent.js'
 
-export default (faker, type, child) => {
-  if (type === '3-in-1 and MenACWY') {
-    const yes = {
-      '3-in-1': CONSENT.GIVEN,
-      'men-acwy': CONSENT.GIVEN,
-      text: CONSENT.GIVEN,
-      both: true,
-      consented: true,
-      responded: true
-    }
-    const no = {
-      '3-in-1': CONSENT.REFUSED,
-      'men-acwy': CONSENT.REFUSED,
-      text: CONSENT.REFUSED,
-      refusedBoth: true,
-      refused: true,
-      responded: true
-    }
-    const unknown = {
-      '3-in-1': CONSENT.UNKNOWN,
-      'men-acwy': CONSENT.UNKNOWN,
-      text: CONSENT.UNKNOWN,
-      unknown: true,
-      responded: false
+export default (faker, { type, child, count }) => {
+  const consentResponses = []
+  for (let i = 0; i < count; i++) {
+    if (type === '3-in-1 and MenACWY') {
+      const yes = {
+        '3-in-1': CONSENT.GIVEN,
+        'men-acwy': CONSENT.GIVEN,
+        text: CONSENT.GIVEN,
+        both: true,
+        consented: true,
+        responded: true
+      }
+      const no = {
+        '3-in-1': CONSENT.REFUSED,
+        'men-acwy': CONSENT.REFUSED,
+        text: CONSENT.REFUSED,
+        refusedBoth: true,
+        refused: true,
+        responded: true
+      }
+      const unknown = {
+        '3-in-1': CONSENT.UNKNOWN,
+        'men-acwy': CONSENT.UNKNOWN,
+        text: CONSENT.UNKNOWN,
+        unknown: true,
+        responded: false
+      }
+
+      return faker.helpers.arrayElement(
+        [
+          ...Array(5).fill(yes),
+          { '3-in-1': CONSENT.REFUSED, 'men-acwy': CONSENT.GIVEN, text: CONSENT.ONLY_MENACWY, responded: true, consented: true },
+          { '3-in-1': CONSENT.GIVEN, 'men-acwy': CONSENT.REFUSED, text: CONSENT.ONLY_3_IN_1, responded: true, consented: true },
+          ...Array(5).fill(unknown),
+          ...Array(2).fill(no)
+        ]
+      )
     }
 
-    return faker.helpers.arrayElement(
-      [
-        ...Array(5).fill(yes),
-        { '3-in-1': CONSENT.REFUSED, 'men-acwy': CONSENT.GIVEN, text: CONSENT.ONLY_MENACWY, responded: true, consented: true },
-        { '3-in-1': CONSENT.GIVEN, 'men-acwy': CONSENT.REFUSED, text: CONSENT.ONLY_3_IN_1, responded: true, consented: true },
-        ...Array(5).fill(unknown),
-        ...Array(2).fill(no)
-      ]
-    )
+    let reason = null
+    let reasonDetails = null
+    if (child.consent === CONSENT.REFUSED) {
+      let availableReasons = Object.values(REFUSAL_REASON)
+      if (type !== 'Flu') {
+        availableReasons = availableReasons.filter(a => {
+          return a !== REFUSAL_REASON.GELATINE
+        })
+      }
+      reason = faker.helpers.arrayElement(availableReasons)
+
+      if (reason === REFUSAL_REASON.OTHER) {
+        reasonDetails = 'My family rejects vaccinations on principle.'
+      }
+    }
+
+    const days = faker.number.int({ min: 10, max: 35 })
+
+    const method = faker.helpers.arrayElement([
+      ...Array(5).fill('Website'),
+      'Text message',
+      'Telephone',
+      'In person',
+      'Paper'
+    ])
+
+    const parentOrGuardian = child.consent !== CONSENT.UNKNOWN ? getParent(faker, child.lastName) : {}
+
+    consentResponses.push({
+      [type]: child.consent,
+      date: DateTime.local().minus({ days }).toISODate(),
+      method,
+      parentOrGuardian,
+      healthAnswers: getHealthAnswers(faker, type, child),
+      ...reason && { reason },
+      ...reasonDetails && { reasonDetails }
+    })
   }
 
-  let reason = null
-  let reasonDetails = null
-  if (child.consent === CONSENT.REFUSED) {
-    let availableReasons = Object.values(REFUSAL_REASON)
-    if (type !== 'Flu') {
-      availableReasons = availableReasons.filter(a => {
-        return a !== REFUSAL_REASON.GELATINE
-      })
-    }
-    reason = faker.helpers.arrayElement(availableReasons)
-
-    if (reason === REFUSAL_REASON.OTHER) {
-      reasonDetails = 'My family rejects vaccinations on principle.'
-    }
-  }
-
-  const days = faker.number.int({ min: 10, max: 35 })
-
-  const method = faker.helpers.arrayElement([
-    ...Array(5).fill('Website'),
-    'Text message',
-    'Telephone',
-    'In person',
-    'Paper'
-  ])
-
-  const parentOrGuardian = child.consent !== CONSENT.UNKNOWN ? getParent(faker, child.lastName) : {}
-
-  return [{
-    [type]: child.consent,
-    date: DateTime.local().minus({ days }).toISODate(),
-    method,
-    parentOrGuardian,
-    healthAnswers: getHealthAnswers(faker, type, child),
-    reason,
-    reasonDetails
-  }]
+  return _.uniqBy(consentResponses, 'parentOrGuardian.relationship')
 }

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -1,88 +1,14 @@
-import { DateTime } from 'luxon'
-import { CONSENT, REFUSAL_REASON } from '../enums.js'
-import getParent from './parent.js'
+import { CONSENT } from '../enums.js'
 
-export default (faker, type, childsLastName) => {
-  if (type === '3-in-1 and MenACWY') {
-    const yes = {
-      '3-in-1': CONSENT.GIVEN,
-      'men-acwy': CONSENT.GIVEN,
-      text: CONSENT.GIVEN,
-      both: true,
-      consented: true,
-      responded: true
-    }
-    const no = {
-      '3-in-1': CONSENT.REFUSED,
-      'men-acwy': CONSENT.REFUSED,
-      text: CONSENT.REFUSED,
-      refusedBoth: true,
-      refused: true,
-      responded: true
-    }
-    const unknown = {
-      '3-in-1': CONSENT.UNKNOWN,
-      'men-acwy': CONSENT.UNKNOWN,
-      text: CONSENT.UNKNOWN,
-      unknown: true,
-      responded: false
-    }
-
-    return faker.helpers.arrayElement(
-      [
-        ...Array(5).fill(yes),
-        { '3-in-1': CONSENT.REFUSED, 'men-acwy': CONSENT.GIVEN, text: CONSENT.ONLY_MENACWY, responded: true, consented: true },
-        { '3-in-1': CONSENT.GIVEN, 'men-acwy': CONSENT.REFUSED, text: CONSENT.ONLY_3_IN_1, responded: true, consented: true },
-        ...Array(5).fill(unknown),
-        ...Array(2).fill(no)
-      ]
-    )
-  }
-
-  const consent = faker.helpers.arrayElement([
-    ...Array(10).fill(CONSENT.GIVEN),
-    ...Array(5).fill(CONSENT.UNKNOWN),
-    CONSENT.REFUSED
-  ])
-
-  let reason = null
-  let reasonDetails = null
-  if (consent === CONSENT.REFUSED) {
-    let availableReasons = Object.values(REFUSAL_REASON)
-    if (type !== 'Flu') {
-      availableReasons = availableReasons.filter(a => {
-        return a !== REFUSAL_REASON.GELATINE
-      })
-    }
-    reason = faker.helpers.arrayElement(availableReasons)
-
-    if (reason === REFUSAL_REASON.OTHER) {
-      reasonDetails = 'My family rejects vaccinations on principle.'
-    }
-  }
-
-  const days = faker.number.int({ min: 10, max: 35 })
-
-  const method = faker.helpers.arrayElement([
-    ...Array(5).fill('Website'),
-    'Text message',
-    'Telephone',
-    'In person',
-    'Paper'
-  ])
-
-  const parentOrGuardian = consent !== CONSENT.UNKNOWN ? getParent(faker, childsLastName) : {}
+export default (type, consentResponses) => {
+  const consentResponse = consentResponses[0][type]
 
   return {
-    [type]: consent,
-    text: consent,
-    refused: consent === CONSENT.REFUSED,
-    consented: consent === CONSENT.GIVEN,
-    responded: consent !== CONSENT.UNKNOWN,
-    date: DateTime.local().minus({ days }).toISODate(),
-    method,
-    parentOrGuardian,
-    reason,
-    reasonDetails
+    [type]: consentResponse,
+    text: consentResponse,
+    refused: consentResponse === CONSENT.REFUSED,
+    consented: consentResponse === CONSENT.GIVEN,
+    responded: consentResponse !== CONSENT.UNKNOWN,
+    answersNeedTriage: consentResponse.answersNeedTriage
   }
 }

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -1,14 +1,18 @@
+import { faker } from '@faker-js/faker'
 import { CONSENT } from '../enums.js'
 
-export default (type, consentResponses) => {
-  const consentResponse = consentResponses[0][type]
+export default (type) => {
+  const consent = faker.helpers.arrayElement([
+    ...Array(10).fill(CONSENT.GIVEN),
+    ...Array(5).fill(CONSENT.UNKNOWN),
+    CONSENT.REFUSED
+  ])
 
   return {
-    [type]: consentResponse,
-    text: consentResponse,
-    refused: consentResponse === CONSENT.REFUSED,
-    consented: consentResponse === CONSENT.GIVEN,
-    responded: consentResponse !== CONSENT.UNKNOWN,
-    answersNeedTriage: consentResponse.answersNeedTriage
+    [type]: consent,
+    text: consent,
+    refused: consent === CONSENT.REFUSED,
+    consented: consent === CONSENT.GIVEN,
+    responded: consent !== CONSENT.UNKNOWN
   }
 }

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -2,17 +2,19 @@ import { faker } from '@faker-js/faker'
 import { CONSENT } from '../enums.js'
 
 export default (type) => {
-  const consent = faker.helpers.arrayElement([
+  let consent = faker.helpers.arrayElement([
     ...Array(10).fill(CONSENT.GIVEN),
-    ...Array(5).fill(CONSENT.UNKNOWN),
     CONSENT.REFUSED
   ])
 
-  return {
-    [type]: consent,
-    text: consent,
-    refused: consent === CONSENT.REFUSED,
-    consented: consent === CONSENT.GIVEN,
-    responded: consent !== CONSENT.UNKNOWN
+  if (type === '3-in-1 and MenACWY') {
+    consent = faker.helpers.arrayElement([
+      ...Array(5).fill(CONSENT.GIVEN),
+      ...Array(5).fill(CONSENT.ONLY_MENACWY),
+      ...Array(5).fill(CONSENT.ONLY_3_IN_1),
+      ...Array(2).fill(CONSENT.REFUSED)
+    ])
   }
+
+  return consent
 }

--- a/app/generators/derived-consent.js
+++ b/app/generators/derived-consent.js
@@ -1,0 +1,62 @@
+import _ from 'lodash'
+import { CONSENT } from '../enums.js'
+
+export default (type, consentResponses) => {
+  // Only derive consent from responses for this campaign type
+  consentResponses = _.uniqBy(consentResponses, type)
+
+  let consent = CONSENT.UNKNOWN
+  let consented // All responses consented
+  let refused // All responses refused
+  let inconsistent // All consent responses mixed
+
+  if (consentResponses.length === 1) {
+    consent = consentResponses[0][type]
+    consented = consentResponses[0][type] === CONSENT.GIVEN
+    refused = consentResponses[0][type] === CONSENT.REFUSED
+  } else if (consentResponses.length > 1) {
+    const allConsented = _.uniqBy(consentResponses, type) === CONSENT.GIVEN
+    if (allConsented) {
+      consent = CONSENT.GIVEN
+      consented = true
+    }
+
+    const allRefused = _.uniqBy(consentResponses, type) === CONSENT.REFUSED
+    if (allRefused) {
+      consent = CONSENT.REFUSED
+      refused = true
+    }
+
+    consent = CONSENT.INCONSISTENT
+    inconsistent = true
+  }
+
+  // Build a list of health answers with responses
+  const answersNeedingTriage = []
+  if (consented) {
+    for (consent of Object.values(consentResponses)) {
+      for (const [key, value] of Object.entries(consent.healthAnswers)) {
+        if (value !== false) {
+          answersNeedingTriage.push(key)
+        }
+      }
+    }
+  }
+
+  const derivedConsent = {
+    [type]: consent,
+    text: consent,
+    refused,
+    consented,
+    inconsistent,
+    unknown: consentResponses.length === 0,
+    responses: consentResponses.length > 0,
+    answersNeedTriage: answersNeedingTriage.length > 0,
+    ...(type === '3-in-1 and MenACWY') && {
+      refusedBoth: consent === CONSENT.REFUSED,
+      both: consent === CONSENT.GIVEN
+    }
+  }
+
+  return derivedConsent
+}

--- a/app/generators/health-answers.js
+++ b/app/generators/health-answers.js
@@ -137,12 +137,6 @@ const realisticAnswers = {
 }
 
 const enrichWithRealisticAnswers = (faker, child, healthAnswers) => {
-  // Did not answer health questions as either
-  // they refused consent or did not respond
-  if (child.consent.refused || !child.consent.responded) {
-    return healthAnswers
-  }
-
   // Do not give health question responses to 80% of children who consent
   if (faker.helpers.maybe(() => true, { probability: 0.8 })) {
     return healthAnswers
@@ -153,7 +147,6 @@ const enrichWithRealisticAnswers = (faker, child, healthAnswers) => {
   for (const key of Object.keys(healthAnswers)) {
     if (realisticAnswers[realisticAnswer][key]) {
       healthAnswers[key] = realisticAnswers[realisticAnswer][key]
-      child.consent.answersNeedTriage = true
 
       // Save realistic triage note for use later in generation process
       child.__triageNote = realisticAnswers[realisticAnswer].triageNote

--- a/app/generators/health-answers.js
+++ b/app/generators/health-answers.js
@@ -1,37 +1,4 @@
-export default (faker, type, child) => {
-  let questions = []
-  const allergy = { title: 'Allergies', id: 'allergy', question: 'Does the child have any severe allergies that have led to an anaphylactic reaction?', answer: 'No' }
-  const medicalConditions = { title: 'Medical conditions', id: 'medicalConditions', question: 'Does the child have any existing medical conditions?', answer: 'No' }
-
-  switch (type) {
-    case 'Flu':
-      questions = [
-        { title: 'Immunity', id: 'their-immune', question: 'Does the child have a disease or treatment that severely affects their immune system?', answer: 'No' },
-        { title: 'Household immunity', id: 'household-immune', question: 'Is anyone in your household having treatment that severely affects their immune system?', answer: 'No' },
-        { title: 'Asthma', id: 'asthma', question: 'Has your child been diagnosed with asthma?', answer: 'No' },
-        { title: 'Egg allergy', id: 'egg-allergy', question: 'Has your child been admitted to intensive care because of a severe egg allergy?', answer: 'No' }
-      ]
-      break
-    case 'HPV':
-      questions = [
-        allergy,
-        medicalConditions,
-        { title: 'Medication', id: 'medication', question: 'Does the child take any regular medication?', answer: 'No' }
-      ]
-      break
-    case '3-in-1 and MenACWY':
-      questions = [
-        allergy,
-        medicalConditions,
-        { title: 'Immunosuppressant', id: 'immunosuppressant', question: 'Does the child take any immunosuppressant medication?', answer: 'No' }
-      ]
-      break
-  }
-
-  questions.push({ title: 'Anything else', id: 'anythingElse', question: 'Is there anything else we should know?', answer: 'No' })
-
-  return enrichWithRealisticAnswers(faker, child, { questions })
-}
+import getHealthQuestions from './health-questions.js'
 
 const realisticAnswers = {
   adhd: {
@@ -51,13 +18,13 @@ const realisticAnswers = {
     triageNote: 'Spoke with parent. Child has an anxiety disorder, takes medication to manage it. No medical issues that would impact vaccine administration. It is safe to vaccinate.'
   },
   asthma: {
-    medicalConditions: 'My child was diagnosed with asthma a few months ago and it has been quite challenging for them. They have struggled with breathing difficulties and have needed to use their inhaler several times a day.',
-    medication: 'My child takes medication every day to manage their asthma',
+    asthma: 'My child was diagnosed with asthma a few months ago and it has been quite challenging for them. They have struggled with breathing difficulties and have needed to use their inhaler several times a day.',
+    asthmaSteroids: 'My child takes medication every day to manage their asthma',
     triageNote: 'Spoke with parent. Child has asthma, takes daily medication. Safe to give vaccine'
   },
   asthmaAndAllergies: {
-    medicalConditions: 'My child has asthma and multiple allergies, including environmental and food allergies.',
-    medication: 'My child takes medication to manage their asthma and prevent breathing difficulties. They also carry an EpiPen in case of anaphylactic reactions.',
+    asthma: 'My child has asthma and multiple allergies, including environmental and food allergies.',
+    asthmaSteroids: 'My child takes medication to manage their asthma and prevent breathing difficulties. They also carry an EpiPen in case of anaphylactic reactions.',
     anythingElse: 'My child has a history of anaphylactic reactions and must avoid certain foods and environments to prevent reactions.',
     triageNote: 'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
@@ -69,10 +36,12 @@ const realisticAnswers = {
   },
   badExperience: {
     anythingElse: 'My child had a bad experience with a vaccine before, I just want to make sure they are comfortable and safe',
+    previousReaction: 'My child recently had a bad reaction to a different vaccine.',
     triageNote: 'I have spoken to the parent and they mentioned that the child had a bad experience with a vaccine before. It is important to ensure the child is comfortable and at ease during the vaccine process. I suggest discussing any concerns with the child and addressing them before proceeding with the vaccine. It is safe to give the vaccine with these measures in place.'
   },
   badReaction: {
     anythingElse: 'My child recently had a bad reaction to a different vaccine. I just want to make sure we are extra cautious with this.',
+    previousReaction: 'My child recently had a bad reaction to a different vaccine.',
     triageNote: 'Spoke with parent, confirmed bad reaction from previous vaccine. Vaccine was a COVID-19 vaccination and the reaction was swelling at the site of vaccination. Safe to vaccinate with caution. Monitor for adverse reactions post-vaccination.'
   },
   bleedingDisorder: {
@@ -92,9 +61,14 @@ const realisticAnswers = {
     triageNote: 'Spoke with parent, child has chronic pain due to previous injury and takes medication. Vaccinator should be aware of child’s condition and take extra care during vaccine administration to minimize any discomfort. Monitor for any adverse reactions during and after vaccine administration.'
   },
   coeliacDisease: {
+    eggAllergy: 'My child has coeliac disease and must follow a strict gluten-free diet.',
     medicalConditions: 'My child has coeliac disease and must follow a strict gluten-free diet.',
     medication: 'My child does not take medication, but follows a strict gluten-free diet to manage their coeliac disease.',
     triageNote: 'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
+  },
+  covid19: {
+    householdImmuneSystem: 'Their grandmother lives with us, and has recently got covid.',
+    triageNote: 'Spoke with parent. Child has sufficiently recovered. It is safe to vaccinate'
   },
   depression: {
     medicalConditions: 'My child has depression and experiences feelings of sadness and hopelessness on a regular basis.',
@@ -126,10 +100,12 @@ const realisticAnswers = {
   },
   fainting: {
     anythingElse: 'My child has a history of fainting after receiving injections.',
+    previousReaction: 'My child has a history of fainting after receiving injections.',
     triageNote: 'I have spoken to the parent and gathered that the child has a history of fainting after receiving injections. It is recommended to observe the child for 15 minutes after the vaccine is given, to monitor for any adverse reactions. The vaccine can be safely given with this precaution in place.'
   },
   foodAllergy: {
-    allergy: 'Yes, my child has a food allergy to dairy products and has had an anaphylactic reaction in the past.',
+    allergy: 'My child has a food allergy to dairy products and had an anaphylactic reaction in the past.',
+    eggAllergy: 'My child has an allergy to dairy products and had an anaphylactic reaction in the past.',
     medication: 'My child carries an EpiPen with them at all times in case of another reaction.',
     triageNote: 'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
@@ -160,29 +136,45 @@ const realisticAnswers = {
   }
 }
 
-const enrichWithRealisticAnswers = (faker, child, health) => {
+const enrichWithRealisticAnswers = (faker, child, healthAnswers) => {
   // Did not answer health questions as either
   // they refused consent or did not respond
   if (child.consent.refused || !child.consent.responded) {
-    return health
+    return healthAnswers
   }
 
   // Do not give health question responses to 80% of children who consent
   if (faker.helpers.maybe(() => true, { probability: 0.8 })) {
-    return health
+    return healthAnswers
   }
 
-  const answer = faker.helpers.objectKey(realisticAnswers)
-  health.questions.forEach((question) => {
-    if (realisticAnswers[answer][question.id]) {
-      question.details = realisticAnswers[answer][question.id]
-      question.answer = 'Yes'
+  const realisticAnswer = faker.helpers.objectKey(realisticAnswers)
+
+  for (const key of Object.keys(healthAnswers)) {
+    if (realisticAnswers[realisticAnswer][key]) {
+      healthAnswers[key] = realisticAnswers[realisticAnswer][key]
       child.consent.answersNeedTriage = true
+
+      // Save realistic triage note for use later in generation process
+      child.__triageNote = realisticAnswers[realisticAnswer].triageNote
     }
-  })
+  }
 
-  // Save realistic triage note for use later in generation process
-  child.__triageNote = realisticAnswers[answer].triageNote
+  return healthAnswers
+}
 
-  return health
+export default (faker, type, child) => {
+  const healthQuestions = getHealthQuestions(type)
+
+  const answers = {}
+
+  // Default answer to `false` for most questions
+  for (const key of Object.keys(healthQuestions)) {
+    answers[key] = false
+  }
+
+  // Enrich answers with realistic responses
+  const healthAnswers = enrichWithRealisticAnswers(faker, child, answers)
+
+  return healthAnswers
 }

--- a/app/generators/health-questions.js
+++ b/app/generators/health-questions.js
@@ -1,0 +1,42 @@
+export default (type) => {
+  let questions = []
+
+  const allergy = 'Does the child have any severe allergies that have led to an anaphylactic reaction?'
+  const medicalConditions = 'Does the child have any existing medical conditions?'
+  const anythingElse = 'Is there anything else we should know?'
+
+  switch (type) {
+    case 'Flu':
+      questions = {
+        asthma: 'Has your child been diagnosed with asthma?',
+        asthmaSteroids: 'Has your child taken any oral steroids for their asthma in the last 2 weeks?',
+        asthmaAdmitted: 'Has your child been admitted to intensive care for their asthma?',
+        recentFluVaccination: 'Has your child had a flu vaccination in the last 5 months?',
+        immuneSystem: 'Does your child have a disease or treatment that severely affects their immune system?',
+        householdImmuneSystem: 'Is anyone in your household currently having treatment that severely affects their immune system?',
+        eggAllergy: 'Has your child ever been admitted to intensive care due an allergic reaction to egg?',
+        medicationAllergies: 'Does your child have any allergies to medication?',
+        previousReaction: 'Has your child ever had a reaction to previous vaccinations?',
+        aspirin: 'Does you child take regular aspirin?'
+      }
+      break
+    case 'HPV':
+      questions = {
+        allergy,
+        medicalConditions,
+        medication: 'Does the child take any regular medication?',
+        anythingElse
+      }
+      break
+    case '3-in-1 and MenACWY':
+      questions = {
+        allergy,
+        medicalConditions,
+        immunosuppressant: 'Does the child take any immunosuppressant medication?',
+        anythingElse
+      }
+      break
+  }
+
+  return questions
+}

--- a/app/generators/refusal.js
+++ b/app/generators/refusal.js
@@ -1,0 +1,20 @@
+import { faker } from '@faker-js/faker'
+import { REFUSAL_REASON } from '../enums.js'
+
+export default (type) => {
+  let availableReasons = Object.values(REFUSAL_REASON)
+  if (type !== 'Flu') {
+    availableReasons = availableReasons.filter(a => {
+      return a !== REFUSAL_REASON.GELATINE
+    })
+  }
+
+  const reason = faker.helpers.arrayElement(availableReasons)
+
+  let reasonDetails
+  if (reason === REFUSAL_REASON.OTHER) {
+    reasonDetails = 'My family rejects vaccinations on principle.'
+  }
+
+  return { reason, reasonDetails }
+}

--- a/app/generators/triage-needed.js
+++ b/app/generators/triage-needed.js
@@ -1,10 +1,11 @@
 import { TRIAGE_REASON, ACTION_NEEDED } from '../enums.js'
 
-export default (faker, child) => {
+export default (child) => {
   const triageReasons = []
   child.needsTriage = false
 
-  if (!child.consent.consented) {
+  // No responses
+  if (!child.consent.responses) {
     return
   }
 
@@ -14,7 +15,7 @@ export default (faker, child) => {
     triageReasons.push(TRIAGE_REASON.HAS_NOTES)
   }
 
-  if (faker.helpers.maybe(() => true, { probability: 0.1 })) {
+  if (child.consent.unknown) {
     child.needsTriage = true
     child.actionNeeded = ACTION_NEEDED.TRIAGE
     triageReasons.push(TRIAGE_REASON.INCONSISTENT_CONSENT)

--- a/app/generators/triage-needed.js
+++ b/app/generators/triage-needed.js
@@ -9,13 +9,15 @@ export default (child) => {
     return
   }
 
+  // Answered yes to health questions
   if (child.consent.answersNeedTriage) {
     child.needsTriage = true
     child.actionNeeded = ACTION_NEEDED.TRIAGE
     triageReasons.push(TRIAGE_REASON.HAS_NOTES)
   }
 
-  if (child.consent.unknown) {
+  // Inconsistent consent response
+  if (child.consent.inconsistent) {
     child.needsTriage = true
     child.actionNeeded = ACTION_NEEDED.TRIAGE
     triageReasons.push(TRIAGE_REASON.INCONSISTENT_CONSENT)

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -81,7 +81,7 @@ export default (router) => {
     child.consent.text = consentData.consent
     child.consent.consented = consentData.consent === CONSENT.GIVEN
     child.consent.refused = consentData.consent === CONSENT.REFUSED
-    child.consent.responded = consentData.consent !== CONSENT.UNKNOWN
+    child.consent.responses = consentData.consent !== CONSENT.UNKNOWN
 
     const consentResponse = child.consentResponses[0]
     consentResponse.date = DateTime.local().toISODate()

--- a/app/routes/consent.js
+++ b/app/routes/consent.js
@@ -41,28 +41,23 @@ export default (router) => {
     '/consent/:campaignId/:nhsNumber/health-questions'
   ], (req, res, next) => {
     const child = res.locals.child
-    const healthAnswers = _.get(
+    const formAnswers = _.get(
       req.body,
       `consent.${req.params.campaignId}.${req.params.nhsNumber}.health`, {}
     )
 
-    for (const [key, value] of Object.entries(healthAnswers)) {
+    for (const key of Object.keys(formAnswers)) {
       if (key === 'details') {
         continue
       }
 
-      const details = healthAnswers.details[key] || false
-      const question = child.healthAnswers.questions.find(q => q.id === key)
-      if (question) {
-        question.answer = value
+      if (formAnswers[key] === 'Yes') {
+        child.consent.answersNeedTriage = true
 
-        if (value === 'Yes' || details) {
-          child.consent.answersNeedTriage = true
-        }
-
-        if (details) {
-          question.details = details
-        }
+        // Use detail answer if provided, else return `true`
+        child.healthAnswers[key] = formAnswers.details[key] || true
+      } else {
+        child.healthAnswers[key] = false
       }
     }
 

--- a/app/views/campaign/child-triage.html
+++ b/app/views/campaign/child-triage.html
@@ -24,7 +24,7 @@
         <div class="nhsuk-grid-column-two-thirds">
           {% if child.needsTriage %}
             {% include "campaign/child/_triage-banner.html" %}
-          {% elseif not child.consent.responded or child.consent.refused %}
+          {% elseif not child.consent.responses or child.consent.refused %}
             {% include "campaign/child/_consent-banner.html" %}
           {% endif %}
 
@@ -35,7 +35,7 @@
             {% include "campaign/child/_triage-health-questions.html" %}
           {% endif %}
 
-          {% if child.consent.responded %}
+          {% if child.consent.responses %}
             {% include "campaign/child/_triage.html" %}
           {% endif %}
 

--- a/app/views/campaign/child.html
+++ b/app/views/campaign/child.html
@@ -31,7 +31,7 @@
             {% include "campaign/child/_outcome-banner.html" %}
           {% endif %}
 
-          {% if child.consent.responded %}
+          {% if child.consent.responses %}
             {% include "campaign/child/_consent-triage.html" %}
           {% endif %}
         </div>

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -1,40 +1,42 @@
-{% set parentContactDetailsHtml %}
-  <div class="nhsuk-u-margin-top-2 nhsuk-u-font-size-16">
-    Telephone: {{ child.consent.parentOrGuardian.telephone }}<br>
-    Email: {{ child.consent.parentOrGuardian.email }}
-  </div>
-{% endset %}
-
 {% set consentHtml %}
-  {{ summaryList({
+  {% for response in child.consentResponses %}
+    {% set parentContactDetailsHtml %}
+      <div class="nhsuk-u-margin-top-2 nhsuk-u-font-size-16">
+        Telephone: {{ response.parentOrGuardian.telephone }}<br>
+        Email: {{ response.parentOrGuardian.email }}
+      </div>
+    {% endset %}
+
+    {{ summaryList({
       classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
       rows: decorateRows([
         {
           key: "Given by" if consented else "Refused by",
-          value: child.consent.parentOrGuardian.relationship
+          value: response.parentOrGuardian.relationship
         },
         {
           key: "Reason for refusal",
           value: {
-            html: child.consent.reason | default("Personal choice") + (" – " + child.consent.reasonDetails if child.consent.reason == "Other")
+            html: response.reason | default("Personal choice") + (" – " + response.reasonDetails if response.reason == "Other")
           }
         } if not consented,
         {
-          key: child.consent.parentOrGuardian.relationship,
+          key: response.parentOrGuardian.relationship,
           value: {
-            html: child.consent.parentOrGuardian.fullName + ( parentContactDetailsHtml if child.consent.responded )
+            html: response.parentOrGuardian.fullName + ( parentContactDetailsHtml if child.consent.responded )
           }
         },
         {
           key: "Date",
-          value: child.consent.date | govukDate
+          value: response.date | govukDate
         },
         {
           key: "Type of consent",
-          value: child.consent.method
+          value: response.method
         }
       ])
     }) }}
+  {% endfor %}
 {% endset %}
 
 {% set noResponseHtml %}

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -52,5 +52,5 @@
   heading: "Consent",
   headingLevel: "2",
   headingClasses: "nhsuk-heading-m",
-  description: consentHtml if child.consent.responded else noResponseHtml
+  description: consentHtml if child.consent.responses else noResponseHtml
 }) }}

--- a/app/views/campaign/child/_consent-triage.html
+++ b/app/views/campaign/child/_consent-triage.html
@@ -7,34 +7,35 @@
       </div>
     {% endset %}
 
-    {{ summaryList({
-      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
-      rows: decorateRows([
-        {
-          key: "Given by" if consented else "Refused by",
-          value: response.parentOrGuardian.relationship
-        },
-        {
-          key: "Reason for refusal",
-          value: {
-            html: response.reason | default("Personal choice") + (" – " + response.reasonDetails if response.reason == "Other")
+    {% set detailText %}
+      {{ response[campaign.type] + " by " + response.parentOrGuardian.relationship }} on {{ response.date | govukDate }}
+    {% endset %}
+
+    {{ details({
+      classes: "nhsuk-u-margin-bottom-0" if loop.last,
+      attributes: { open: true },
+      text: detailText,
+      HTML: summaryList({
+        classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
+        rows: decorateRows([
+          {
+            key: "Reason for refusal",
+            value: {
+              html: response.reason | default("Personal choice") + (" – " + response.reasonDetails if response.reason == "Other")
+            }
+          } if response.reason,
+          {
+            key: response.parentOrGuardian.relationship,
+            value: {
+              html: response.parentOrGuardian.fullName + ( parentContactDetailsHtml if child.consent.responded )
+            }
+          },
+          {
+            key: "Type of consent",
+            value: response.method
           }
-        } if not consented,
-        {
-          key: response.parentOrGuardian.relationship,
-          value: {
-            html: response.parentOrGuardian.fullName + ( parentContactDetailsHtml if child.consent.responded )
-          }
-        },
-        {
-          key: "Date",
-          value: response.date | govukDate
-        },
-        {
-          key: "Type of consent",
-          value: response.method
-        }
-      ])
+        ])
+      })
     }) }}
   {% endfor %}
 {% endset %}

--- a/app/views/campaign/child/_details.html
+++ b/app/views/campaign/child/_details.html
@@ -37,25 +37,25 @@
           value: {
             html: child.address
           }
-        } if child.consent.responded,
+        } if child.consent.responses,
         {
           key: "GP",
           value: child.gp
-        } if child.consent.responded,
+        } if child.consent.responses,
         {
           key: "NHS Number",
           value: child.nhsNumber | formatNHSNumber
-        } if child.consent.responded,
+        } if child.consent.responses,
         {
           key: "Vaccination history",
           value: {
             html: "<a href=\"#\">Record available</a>"
           }
-        } if child.consent.responded,
+        } if child.consent.responses,
         {
           key: child.consent.parentOrGuardian.relationship,
           value: {
-            html: child.consent.parentOrGuardian.fullName + ( parentContactDetailsHtml if child.consent.responded )
+            html: child.consent.parentOrGuardian.fullName + ( parentContactDetailsHtml if child.consent.responses )
           }
         } if child.consent.parentOrGuardian.relationship and not triaging
       ])

--- a/app/views/campaign/child/_health-questions.html
+++ b/app/views/campaign/child/_health-questions.html
@@ -1,9 +1,17 @@
-{% for question in child.healthAnswers.questions %}
+{% for id, question in campaign.healthQuestions %}
   <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2 {% if not loop.first %}nhsuk-u-margin-top-4{% endif %}">
-    {{ question.question }}
+    {{ question }}
   </h3>
 
   <p class="nhsuk-u-margin-bottom-0">
-    {{ question.answer }}{% if question.details %} – {{ question.details }}{% endif %}
+    {#- Response can be `true` if no detailed answer given -#}
+    {%- if child.healthAnswers[id] -%}
+      Yes
+      {%- if child.healthAnswers[id] != true %}
+        – {{ child.healthAnswers[id] }}
+      {%- endif-%}
+    {%- else -%}
+      No
+    {%- endif -%}
   </p>
 {% endfor %}

--- a/app/views/campaign/child/_health-questions.html
+++ b/app/views/campaign/child/_health-questions.html
@@ -3,17 +3,18 @@
     {{ question }}
   </h3>
 
-  {% for response in child.consentResponses %}
-    <p class="nhsuk-u-margin-bottom-0">
-      {#- Response can be `true` if no detailed answer given -#}
-      {%- if response.healthAnswers[id] -%}
-        Yes
-        {%- if response.healthAnswers[id] != true %}
-          – {{ response.healthAnswers[id] }}
-        {%- endif-%}
-      {%- else -%}
-        No
-      {%- endif -%}
+  {#- Only return responses with health answers that are different -#}
+  {% set uniqueResponses = child.consentResponses | selectattr("healthAnswers") | uniqueFromArrayBy("healthAnswers[" + id + "]") %}
+  {% for response in uniqueResponses %}
+    {%- if uniqueResponses.length > 1 %}
+      {%- set who = (response.parentOrGuardian.relationship if uniqueResponses.length > 1 else "All") + " answered:" -%}
+    {% endif -%}
+    <p class="nhsuk-body">
+      {{- who }} {{ "No" if not response.healthAnswers[id] else "Yes" }}
+    {%- if response.healthAnswers[id] and response.healthAnswers[id] != true %}
+      {{ " – " if response.healthAnswers[id] and response.healthAnswers[id] != true }}
+      {{- response.healthAnswers[id] -}}
     </p>
+    {%- endif -%}
   {% endfor %}
 {% endfor %}

--- a/app/views/campaign/child/_health-questions.html
+++ b/app/views/campaign/child/_health-questions.html
@@ -3,15 +3,17 @@
     {{ question }}
   </h3>
 
-  <p class="nhsuk-u-margin-bottom-0">
-    {#- Response can be `true` if no detailed answer given -#}
-    {%- if child.healthAnswers[id] -%}
-      Yes
-      {%- if child.healthAnswers[id] != true %}
-        – {{ child.healthAnswers[id] }}
-      {%- endif-%}
-    {%- else -%}
-      No
-    {%- endif -%}
-  </p>
+  {% for response in child.consentResponses %}
+    <p class="nhsuk-u-margin-bottom-0">
+      {#- Response can be `true` if no detailed answer given -#}
+      {%- if response.healthAnswers[id] -%}
+        Yes
+        {%- if response.healthAnswers[id] != true %}
+          – {{ response.healthAnswers[id] }}
+        {%- endif-%}
+      {%- else -%}
+        No
+      {%- endif -%}
+    </p>
+  {% endfor %}
 {% endfor %}

--- a/app/views/consent/health-questions.html
+++ b/app/views/consent/health-questions.html
@@ -4,20 +4,20 @@
 {% block form %}
   {{ appHeading({ caption: child.fullName, title: title }) }}
 
-  {% for q in child.healthAnswers.questions %}
+  {% for id, question in campaign.healthQuestions %}
     {% set giveDetailsHtml %}
       {{ textarea({
         label: {
           text: "Give details"
         },
-        decorate: base + "health.details." + q.id
+        decorate: base + "health.details." + id
       }) }}
     {% endset %}
 
     {{ radios({
       fieldset: {
         legend: {
-          text: q.question
+          text: question
         }
       },
       classes: "nhsuk-radios--inline",
@@ -32,7 +32,7 @@
           text: "No"
         }
       ],
-      decorate: base + "health." + q.id
+      decorate: base + "health." + id
     }) }}
   {% endfor %}
 


### PR DESCRIPTION
Update data model to allow a child to have multiple constant responses (`child.consentResponses`), each containing consent data and health answers. The `child.consent` value now returns values derived from all responses.

PR also splits apart health questions for each vaccine from answers provided in a consent response, and displays multiple consent responses in the UI:

<img width="640" alt="Screenshot of multiple consent responses." src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/8320aab9-27c9-4ef2-8892-56c59b768cae">

<img width="640" alt="Screenshot of multiple health question answers" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/a722dc93-9073-4697-9971-819ef76a6b6f">

Later PRs will allow users to select the accepted consent response and add any notes about attempting to obtain consent.