### PR TITLE
Show refusal reasons in triage table

### DIFF
--- a/app/generators/derived-consent.js
+++ b/app/generators/derived-consent.js
@@ -43,6 +43,14 @@ export default (type, consentResponses) => {
     }
   }
 
+  // Build a list of refusal reasons
+  const refusalReasons = []
+  if (refused) {
+    for (consent of Object.values(consentResponses)) {
+      refusalReasons.push(consent.reason)
+    }
+  }
+
   const derivedConsent = {
     [type]: consent,
     text: consent,
@@ -52,6 +60,7 @@ export default (type, consentResponses) => {
     unknown: consentResponses.length === 0,
     responses: consentResponses.length > 0,
     answersNeedTriage: answersNeedingTriage.length > 0,
+    refusalReasons,
     ...(type === '3-in-1 and MenACWY') && {
       refusedBoth: consent === CONSENT.REFUSED,
       both: consent === CONSENT.GIVEN

--- a/app/views/campaign/_children-tab.html
+++ b/app/views/campaign/_children-tab.html
@@ -24,10 +24,10 @@
               <td class="govuk-table__cell">
                 <a href="/campaign/{{ campaign.id }}/child/{{ child.nhsNumber }}">{{ child.fullName }}</a>
                 {% if child.preferredName %}
-                  <br>Known as: {{ child.preferredName }}
+                  <br><span class="nhsuk-u-font-size-16">Known as: {{ child.preferredName }}</span>
                 {% endif %}
               </td>
-              <td class="govuk-table__cell" style="width: 150px">
+              <td class="govuk-table__cell nhsuk-u-font-size-16" style="width: 150px">
                 {{ child.dob | govukDate("truncate") }}
               </td>
               <td class="govuk-table__cell">

--- a/app/views/campaign/_children-triage-tab.html
+++ b/app/views/campaign/_children-triage-tab.html
@@ -8,8 +8,10 @@
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header">Name</th>
-            {% if isReasonNeeded %}
+            {% if isTriageReasonNeeded %}
               <th class="govuk-table__header">Triage reasons</th>
+            {% elif isRefusalReasonNeeded %}
+              <th class="govuk-table__header">Reason for refusal</th>
             {% else %}
               <th class="govuk-table__header">Date of birth</th>
             {% endif %}
@@ -24,18 +26,25 @@
               <td class="govuk-table__cell">
                 <a href="/campaign/{{ campaign.id }}/child-triage/{{ child.nhsNumber }}">{{ child.fullName }}</a>
                 {% if child.preferredName %}
-                  <br>Known as: {{ child.preferredName }}
+                  <br><span class="nhsuk-u-font-size-16">Known as: {{ child.preferredName }}</span>
                 {% endif %}
               </td>
-              {% if isReasonNeeded %}
-                <td class="govuk-table__cell">
+              {% if isTriageReasonNeeded %}
+                <td class="govuk-table__cell nhsuk-u-font-size-16">
                   {% for reason in child.triageReasons %}
-                    {{ reason }}
+                    {{ reason | noOrphans | safe }}
+                    {% if not loop.last %}<br>{% endif %}
+                  {% endfor %}
+                </td>
+              {% elif isRefusalReasonNeeded %}
+                <td class="govuk-table__cell nhsuk-u-font-size-16">
+                  {% for reason in child.consent.refusalReasons %}
+                    {{ reason | noOrphans | safe }}
                     {% if not loop.last %}<br>{% endif %}
                   {% endfor %}
                 </td>
               {% else %}
-                <td class="govuk-table__cell" style="width: 150px">
+                <td class="govuk-table__cell nhsuk-u-font-size-16" style="width: 150px">
                   {{ child.dob | govukDate("truncate") }}
                 </td>
               {% endif %}

--- a/app/views/campaign/children-triage.html
+++ b/app/views/campaign/children-triage.html
@@ -42,25 +42,27 @@
 
           {% set needsTriage %}
             {% set children = filteredChildren.triageNeeded %}
-            {% set isReasonNeeded = true %}
+            {% set isTriageReasonNeeded = true %}
             {% include "campaign/_children-triage-tab.html" %}
           {% endset %}
 
           {% set chaseConsent %}
             {% set children = filteredChildren.chaseConsent %}
-            {% set isReasonNeeded = false %}
+            {% set isTriageReasonNeeded = false %}
+            {% set isRefusalReasonNeeded = true %}
             {% include "campaign/_children-triage-tab.html" %}
           {% endset %}
 
           {% set triageComplete %}
             {% set children = filteredChildren.triageCompleted %}
-            {% set isReasonNeeded = true %}
+            {% set isTriageReasonNeeded = true %}
+            {% set isRefusalReasonNeeded = false %}
             {% include "campaign/_children-triage-tab.html" %}
           {% endset %}
 
           {% set noTriageNeeded %}
             {% set children = filteredChildren.noTriageNeeded %}
-            {% set isReasonNeeded = false %}
+            {% set isTriageReasonNeeded = false %}
             {% include "campaign/_children-triage-tab.html" %}
           {% endset %}
 


### PR DESCRIPTION
Added refusal reasons (plural if multiple consent responses) to a new column under the ‘Get consent’ column:

<img width="705" alt="Screenshot of ‘Get consent’ table." src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/83ea1bda-d561-4fe8-949b-30713c101d50">

Also reduced the font size of triage reasons, date of birth and name known by, as table getting a bit cramped. Which suggests may need to review the presentation of this info later.

<img width="705" alt="Screenshot of ‘Needs triage’ table." src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/ed4ebb49-03c6-4eb9-a18e-af5b05d6fee6">
