### PR TITLE
Fix link to record vaccinations view

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -10,7 +10,7 @@
       <ul class="nhsuk-list">
         <li><a href="/start">Start page</a></li>
         <li><a href="/dashboard">Signed in dashboard</a></li>
-        <li><a href="/go/record-vaccinations">Record vaccinations view</a></li>
+        <li><a href="/go/record">Record vaccinations view</a></li>
         <li><a href="/go/in-progress">In progress session</a></li>
         <li><a href="/go/in-progress-triage">In progress triage</a></li>
         <li><a href="/go/triage">Triage view</a></li>


### PR DESCRIPTION
Looks like the redirect was changed a few commits ago.