### PR TITLE
Dynamic derive triage and consent outcomes

### DIFF
--- a/app/enums.js
+++ b/app/enums.js
@@ -1,5 +1,4 @@
 export const TRIAGE_OUTCOME = {
-  NONE: 'No screening information',
   NEEDS_TRIAGE: 'Needs triage',
   DELAY_VACCINATION: 'Delay vaccination to a later date',
   DO_NOT_VACCINATE: 'Do not vaccinate in campaign',

--- a/app/enums.js
+++ b/app/enums.js
@@ -34,7 +34,7 @@ export const VACCINATION_OUTCOME = {
 
 export const CONSENT_OUTCOME = {
   NO_RESPONSE: 'No response',
-  VALID: 'Consent given',
+  GIVEN: 'Consent given',
   REFUSED: 'Consent refused',
   FINAL_REFUSAL: 'Confirmed refusal, do not contact',
   INCONSISTENT: 'Conflicting',

--- a/app/generators/campaign.js
+++ b/app/generators/campaign.js
@@ -26,8 +26,7 @@ export default () => {
   const school = getSchool(type)
   const atTime = faker.helpers.arrayElement(['09:00', '10:00', '11:00', '12:30', '13:00', '14:00'])
   const daysUntil = faker.number.int({ min: 2, max: 100 })
-  const triageInProgress = daysUntil < 28
-  const options = { ...ageRange(type), triageInProgress }
+  const options = { ...ageRange(type) }
   const cohort = faker.helpers.multiple(getPatient(options), { count: 100 })
     .sort((a, b) => a.fullName.localeCompare(b.fullName))
 
@@ -38,7 +37,7 @@ export default () => {
     date: DateTime.now().plus({ days: daysUntil }).toISODate() + 'T' + atTime,
     type,
     healthQuestions: getHealthQuestions(type),
-    triageInProgress,
+    triageInProgress: daysUntil < 28,
     yearGroups: getYearGroups(type),
     school,
     isFlu: type === 'Flu',

--- a/app/generators/patient.js
+++ b/app/generators/patient.js
@@ -6,12 +6,29 @@ import getChild from './child.js'
 import getResponse from './response.js'
 import { getYearGroup } from './year-group.js'
 
-const getPatient = (options) => {
+/**
+ * @typedef {object} Patient
+ * @property {string} nhsNumber - NHS number
+ * @property {string} address - Address
+ * @property {object} yearGroup - Response method
+ * @property {[import('./response.js').Response]} responses - Parent
+ * @property {object} consent - Consent outcome
+ * @property {string} outcome - Overall patient outcome
+ * @property {object} [seen] - Seen offline
+ * @property {object} triage - Triage outcome
+ */
+
+/**
+ * @private
+ * @param {object} options - Patient options
+ * @returns {Patient} Patient record
+ */
+const _getPatient = (options) => {
   const { minYearGroup, maxYearGroup, type } = options
   const patient = getChild(minYearGroup, maxYearGroup)
 
   let responses = faker.helpers.multiple(getResponse(type, patient), {
-    count: { min: 0, max: 4 }
+    count: { min: 0, max: 3 }
   })
   responses = _.uniqBy(responses, 'parentOrGuardian.relationship')
 
@@ -30,7 +47,7 @@ const getPatient = (options) => {
 
 export default (options) => {
   const patient = () => ({
-    ...getPatient(options)
+    ..._getPatient(options)
   })
 
   return patient

--- a/app/generators/patient.js
+++ b/app/generators/patient.js
@@ -1,9 +1,8 @@
 import _ from 'lodash'
 import { fakerEN_GB as faker } from '@faker-js/faker'
-import { PATIENT_OUTCOME, TRIAGE_OUTCOME } from '../enums.js'
+import { PATIENT_OUTCOME } from '../enums.js'
 import getAddress from './address.js'
 import getChild from './child.js'
-import getConsent from './consent.js'
 import getResponse from './response.js'
 import { getYearGroup } from './year-group.js'
 
@@ -21,17 +20,10 @@ const getPatient = (options) => {
   patient.address = getAddress()
   patient.yearGroup = getYearGroup(patient.dob)
   patient.responses = responses
-  patient.consent = getConsent(type, responses)
+  patient.consent = { notes: [] }
   patient.outcome = PATIENT_OUTCOME.NO_OUTCOME_YET
-
   patient.seen = {}
-
-  patient.triage = {
-    notes: [],
-    outcome: patient.consent.answersNeedTriage
-      ? TRIAGE_OUTCOME.NEEDS_TRIAGE
-      : TRIAGE_OUTCOME.NONE
-  }
+  patient.triage = { notes: [] }
 
   return patient
 }

--- a/app/generators/patient.js
+++ b/app/generators/patient.js
@@ -4,42 +4,11 @@ import { PATIENT_OUTCOME, TRIAGE_OUTCOME } from '../enums.js'
 import getAddress from './address.js'
 import getChild from './child.js'
 import getConsent from './consent.js'
-import getNote from './note.js'
 import getResponse from './response.js'
 import { getYearGroup } from './year-group.js'
 
-const handleInProgressTriage = (patient) => {
-  // Only relevant to patients needing triage
-  if (patient.triage.outcome !== TRIAGE_OUTCOME.NEEDS_TRIAGE) {
-    return
-  }
-
-  // Only half done
-  if (faker.helpers.maybe(() => true, { probability: 0.5 })) {
-    return
-  }
-
-  // Set triage outcome to vaccinate
-  patient.triage.outcome = faker.helpers.weightedArrayElement([
-    { value: TRIAGE_OUTCOME.NEEDS_TRIAGE, weight: 1 },
-    { value: TRIAGE_OUTCOME.VACCINATE, weight: 1 }
-  ])
-
-  // Add realistic triage note
-  if (patient.__triageNote) {
-    patient.triage.notes.push(getNote(patient.__triageNote))
-
-    delete patient.__triageNote
-  }
-
-  // A small number still need follow-up triage, the rest can vaccinate
-  if (faker.helpers.maybe(() => true, { probability: 0.8 })) {
-    patient.triage.outcome = TRIAGE_OUTCOME.VACCINATE
-  }
-}
-
 const getPatient = (options) => {
-  const { minYearGroup, maxYearGroup, triageInProgress, type } = options
+  const { minYearGroup, maxYearGroup, type } = options
   const patient = getChild(minYearGroup, maxYearGroup)
 
   let responses = faker.helpers.multiple(getResponse(type, patient), {
@@ -62,10 +31,6 @@ const getPatient = (options) => {
     outcome: patient.consent.answersNeedTriage
       ? TRIAGE_OUTCOME.NEEDS_TRIAGE
       : TRIAGE_OUTCOME.NONE
-  }
-
-  if (triageInProgress) {
-    handleInProgressTriage(patient)
   }
 
   return patient

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,4 +1,5 @@
 import express from 'express'
+import getTriageOutcome from './utils/triage-outcome.js'
 import vaccinationRoutes from './routes/vaccination.js'
 import daySetupRoutes from './routes/day-setup.js'
 import newCampaignRoutes from './routes/new-campaign.js'
@@ -32,6 +33,16 @@ const offlineChangesCount = (campaigns) => {
   return offlineCount
 }
 
+const updateTriageOutcomes = (campaigns) => {
+  Object.values(campaigns)
+    .filter(campaign => campaign.triageInProgress)
+    .map(campaign => campaign.cohort)
+    .flat()
+    .forEach(patient => getTriageOutcome(patient))
+
+  return campaigns
+}
+
 router.all('*', (req, res, next) => {
   const { campaigns, features } = req.session.data
 
@@ -39,6 +50,7 @@ router.all('*', (req, res, next) => {
   res.locals.isOffline = features.offline.on
   res.locals.hasOfflineChanges = hasOfflineChanges(campaigns)
   res.locals.offlineChangesCount = offlineChangesCount(campaigns)
+  res.locals.campaigns = updateTriageOutcomes(campaigns)
 
   next()
 })

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,4 +1,5 @@
 import express from 'express'
+import getConsentOutcome from './utils/consent-outcome.js'
 import getTriageOutcome from './utils/triage-outcome.js'
 import vaccinationRoutes from './routes/vaccination.js'
 import daySetupRoutes from './routes/day-setup.js'
@@ -33,6 +34,15 @@ const offlineChangesCount = (campaigns) => {
   return offlineCount
 }
 
+const updateConsentOutcomes = (campaigns) => {
+  Object.values(campaigns)
+    .map(campaign => campaign.cohort)
+    .flat()
+    .forEach(patient => getConsentOutcome(patient))
+
+  return campaigns
+}
+
 const updateTriageOutcomes = (campaigns) => {
   Object.values(campaigns)
     .filter(campaign => campaign.triageInProgress)
@@ -45,12 +55,13 @@ const updateTriageOutcomes = (campaigns) => {
 
 router.all('*', (req, res, next) => {
   const { campaigns, features } = req.session.data
+  const campaignsWithConsentOutcomes = updateConsentOutcomes(campaigns)
 
   res.locals.success = req.query.success
   res.locals.isOffline = features.offline.on
   res.locals.hasOfflineChanges = hasOfflineChanges(campaigns)
   res.locals.offlineChangesCount = offlineChangesCount(campaigns)
-  res.locals.campaigns = updateTriageOutcomes(campaigns)
+  res.locals.campaigns = updateTriageOutcomes(campaignsWithConsentOutcomes)
 
   next()
 })

--- a/app/routes/_filters.js
+++ b/app/routes/_filters.js
@@ -11,15 +11,14 @@ const filters = {
     return cohort.filter(({ consent, triage }) => {
       switch (action) {
         case 'get-consent':
-          return consent.outcome === CONSENT_OUTCOME.NO_RESPONSE
+          return consent?.outcome === CONSENT_OUTCOME.NO_RESPONSE
         case 'check-refusal':
-          return consent.outcome === CONSENT_OUTCOME.REFUSED
+          return consent?.outcome === CONSENT_OUTCOME.REFUSED
         case 'triage':
-          return triage.outcome === TRIAGE_OUTCOME.NEEDS_TRIAGE
+          return triage?.outcome === TRIAGE_OUTCOME.NEEDS_TRIAGE
         case 'vaccinate':
-          return triage.outcome === TRIAGE_OUTCOME.VACCINATE ||
-            (consent.outcome === CONSENT_OUTCOME.VALID &&
-            triage.outcome === TRIAGE_OUTCOME.NONE)
+          return triage?.outcome === TRIAGE_OUTCOME.VACCINATE ||
+            consent?.outcome === CONSENT_OUTCOME.VALID
         default:
           return false
       }
@@ -27,7 +26,7 @@ const filters = {
   },
   consentOutcome: (cohort, value) => {
     return cohort.filter(({ consent }) => {
-      return consent.outcome === CONSENT_OUTCOME[value]
+      return consent?.outcome === CONSENT_OUTCOME[value]
     })
   },
   triageOutcome: (cohort, value, req, res) => {
@@ -39,30 +38,29 @@ const filters = {
           outcome === PATIENT_OUTCOME.NO_OUTCOME_YET
       }
 
-      return triage.outcome === TRIAGE_OUTCOME[value] &&
+      return triage?.outcome === TRIAGE_OUTCOME[value] &&
         outcome === PATIENT_OUTCOME.NO_OUTCOME_YET
     })
   },
   triageNeeded: (cohort) => {
     return cohort.filter(({ consent, triage, outcome }) =>
-      consent.outcome === CONSENT_OUTCOME.VALID &&
-      triage.outcome === TRIAGE_OUTCOME.NEEDS_TRIAGE &&
+      consent?.outcome === CONSENT_OUTCOME.VALID &&
+      triage?.outcome === TRIAGE_OUTCOME.NEEDS_TRIAGE &&
       outcome === PATIENT_OUTCOME.NO_OUTCOME_YET
     )
   },
   triageCompleted: (cohort) => {
     return cohort.filter(({ consent, triage, outcome }) =>
-      consent.outcome === CONSENT_OUTCOME.VALID &&
-      triage.outcome !== TRIAGE_OUTCOME.NEEDS_TRIAGE &&
-      triage.outcome !== TRIAGE_OUTCOME.NONE &&
+      consent?.outcome === CONSENT_OUTCOME.VALID &&
+      triage?.outcome !== TRIAGE_OUTCOME.NEEDS_TRIAGE &&
       outcome === PATIENT_OUTCOME.NO_OUTCOME_YET
     )
   },
   noTriageNeeded: (cohort) => {
     return cohort.filter(({ consent, triage, outcome }) =>
       outcome === PATIENT_OUTCOME.NO_OUTCOME_YET &&
-      consent.outcome === CONSENT_OUTCOME.VALID &&
-      triage.outcome === TRIAGE_OUTCOME.NONE
+      consent?.outcome === CONSENT_OUTCOME.VALID &&
+      !triage.outcome
     )
   },
   hasOutcome: (cohort, value) => {

--- a/app/utils/consent-outcome.js
+++ b/app/utils/consent-outcome.js
@@ -11,13 +11,11 @@ import { CONSENT_OUTCOME, RESPONSE_CONSENT } from '../enums.js'
 
 /**
  * Generate derived consent
- * @param {string} type - Campaign type
- * @param {Array} responses - Consent responses
+ * @param {object} patient - Patient record
  * @returns {Consent} Derived consent
  */
-export default (type, responses) => {
-  // Only derive consent from responses for this campaign type
-  responses = _.uniqBy(responses, type)
+export default (patient) => {
+  const { responses } = patient
 
   let outcome = CONSENT_OUTCOME.NO_RESPONSE
 
@@ -57,12 +55,10 @@ export default (type, responses) => {
     }
   }
 
-  const consent = {
+  patient.consent = {
     outcome,
     answersNeedTriage: answersNeedingTriage.length > 0,
     refusalReasons,
     notes: []
   }
-
-  return consent
 }

--- a/app/utils/consent-outcome.js
+++ b/app/utils/consent-outcome.js
@@ -22,17 +22,15 @@ export default (patient) => {
   if (responses.length === 1) {
     outcome = responses[0].status
   } else if (responses.length > 1) {
-    const allConsented = _.uniqBy(responses, 'status') === RESPONSE_CONSENT.GIVEN
-    if (allConsented) {
-      outcome = CONSENT_OUTCOME.VALID
-    }
+    const uniqueStatuses = _.uniqBy(responses, 'status')
 
-    const allRefused = _.uniqBy(responses, 'status') === RESPONSE_CONSENT.REFUSED
-    if (allRefused) {
+    if (uniqueStatuses.length > 1) {
+      outcome = CONSENT_OUTCOME.INCONSISTENT
+    } else if (uniqueStatuses[0].status === RESPONSE_CONSENT.GIVEN) {
+      outcome = CONSENT_OUTCOME.VALID
+    } else if (uniqueStatuses[0].status === RESPONSE_CONSENT.REFUSED) {
       outcome = CONSENT_OUTCOME.REFUSED
     }
-
-    outcome = CONSENT_OUTCOME.INCONSISTENT
   }
 
   // Build a list of health answers with responses
@@ -48,11 +46,12 @@ export default (patient) => {
   }
 
   // Build a list of refusal reasons
-  const refusalReasons = []
+  let refusalReasons = []
   if (outcome === CONSENT_OUTCOME.REFUSED) {
     for (const response of Object.values(responses)) {
       refusalReasons.push(response.refusalReason)
     }
+    refusalReasons = [...new Set(refusalReasons)]
   }
 
   patient.consent = {

--- a/app/utils/triage-outcome.js
+++ b/app/utils/triage-outcome.js
@@ -1,0 +1,24 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { TRIAGE_OUTCOME } from '../enums.js'
+import getNote from '../generators/note.js'
+
+/**
+ * Update patient record with triage outcome
+ * @param {object} patient - Patient record
+ * @returns {object} Updated patient record
+ */
+export default (patient) => {
+  // Only relevant to patients needing triage
+  if (patient.triage.outcome !== TRIAGE_OUTCOME.NEEDS_TRIAGE) {
+    return
+  }
+
+  // Triage half, adding triage note and changing outcome to VACCINATE
+  if (faker.helpers.maybe(() => true, { probability: 0.5 })) {
+    patient.triage.outcome = TRIAGE_OUTCOME.VACCINATE
+
+    patient.triage.notes.push(getNote(patient.__triageNote))
+
+    delete patient.__triageNote
+  }
+}

--- a/app/views/campaign/patient.html
+++ b/app/views/campaign/patient.html
@@ -6,9 +6,7 @@
 {% set hasRefused = patient.consent.outcome == CONSENT_OUTCOME.REFUSED %}
 {% set hasConsented = patient.consent.outcome == CONSENT_OUTCOME.VALID %}
 {% set triageNeeded = patient.triage.outcome == TRIAGE_OUTCOME.NEEDS_TRIAGE %}
-{% set readyToVaccinate = (patient.triage.outcome == TRIAGE_OUTCOME.NONE) or
-                          (patient.triage.outcome == TRIAGE_OUTCOME.VACCINATE)
-%}
+{% set readyToVaccinate = patient.triage.outcome == TRIAGE_OUTCOME.VACCINATE %}
 
 {% block outerContent %}
   {% set referrer = data.referrer or "record" %}


### PR DESCRIPTION
Instead of updating triage and consent outcomes when generating session data, instead derive these values on each page view. This means that each time session data is updated, pages will reflect the current derived outcomes, records will appear in the correct views and with the correct outcome banner.

Also:
* Show a maximum of 3 consent responses instead of 4
* Fix derived consent generator so that responses are individual (thus creating records with conflicting consent)
* Document a few more data models using JSDoc