### PR TITLE
Fix triage journey

### DIFF
--- a/app/generators/patient.js
+++ b/app/generators/patient.js
@@ -42,6 +42,11 @@ const _getPatient = (options) => {
   patient.seen = {}
   patient.triage = { notes: [] }
 
+  // Mark 50% of records as ready for triaged
+  patient.__triageOutcome = faker.helpers.maybe(() => true, {
+    probability: 0.5
+  })
+
   return patient
 }
 

--- a/app/generators/vaccination.js
+++ b/app/generators/vaccination.js
@@ -8,21 +8,26 @@ import { PATIENT_OUTCOME, VACCINATION_OUTCOME, VACCINATION_SITE } from '../enums
  * @returns {object} Vaccination
  */
 export default (campaigns, batches) => {
-  const campaign = Object
+  const inProgressCampaign = Object
     .values(campaigns)
     .find(campaign => campaign.inProgress)
-  const { cohort, id } = campaign
+
+  if (!inProgressCampaign) {
+    return
+  }
+
+  const { cohort, id } = inProgressCampaign
 
   let batch = null
-  if (campaign.isFlu) {
+  if (inProgressCampaign.isFlu) {
     batch = Object
       .values(batches)
       .find(batch => batch.isFlu)
-  } else if (campaign.isHPV) {
+  } else if (inProgressCampaign.isHPV) {
     batch = Object
       .values(batches)
       .find(batch => batch.isHPV)
-  } else if (campaign.is3in1MenACWY) {
+  } else if (inProgressCampaign.is3in1MenACWY) {
     batch = Object
       .values(batches)
       .find(batch => batch.isMenACWY || batch.is3in1)

--- a/app/globals.js
+++ b/app/globals.js
@@ -263,6 +263,7 @@ export default (_env) => {
       }
     } else if (patient.triage.outcome) {
       text = patient.triage.outcome
+      const user = patient.triage.notes.at(-1)?.user.fullName || 'Jane Doe'
 
       switch (patient.triage.outcome) {
         case TRIAGE_OUTCOME.NEEDS_TRIAGE:
@@ -270,15 +271,15 @@ export default (_env) => {
           break
         case TRIAGE_OUTCOME.DO_NOT_VACCINATE:
           colour = 'red'
-          description = `Jane Doe decided that ${patient.fullName} should not be vaccinated.`
+          description = `${user} decided that ${patient.fullName} should not be vaccinated.`
           break
         case TRIAGE_OUTCOME.DELAY_VACCINATION:
           colour = 'red'
-          description = `Jane Doe decided that ${patient.fullName}’s vaccination should be delayed.`
+          description = `${user} decided that ${patient.fullName}’s vaccination should be delayed.`
           break
         default:
           colour = 'purple'
-          description = `Jane Doe decided that ${patient.fullName} is safe to vaccinate.`
+          description = `${user} decided that ${patient.fullName} is safe to vaccinate.`
       }
     } else {
       colour = 'orange'

--- a/app/routes/campaign.js
+++ b/app/routes/campaign.js
@@ -5,7 +5,7 @@ import { vaccination } from '../wizards/vaccination.js'
 import { PATIENT_OUTCOME, TRIAGE_OUTCOME } from '../enums.js'
 
 const offlineChangesCount = (campaign) => {
-  const offlineCount = campaign.cohort
+  const offlineCount = campaign?.cohort
     .reduce((count, patient) => count + (patient.seen.isOffline ? 1 : 0), 0)
 
   return offlineCount

--- a/app/routes/campaign.js
+++ b/app/routes/campaign.js
@@ -56,6 +56,7 @@ export default (router) => {
 
     if (isTriage && triage) {
       patient.triage.outcome = triage.outcome
+      patient.triage.completed = true
 
       // If triage outcome is not to vaccinate, set patient outcome
       if (triage.outcome === TRIAGE_OUTCOME.DO_NOT_VACCINATE) {

--- a/app/utils/consent-outcome.js
+++ b/app/utils/consent-outcome.js
@@ -4,7 +4,6 @@ import { CONSENT_OUTCOME, RESPONSE_CONSENT, TRIAGE_OUTCOME } from '../enums.js'
 /**
  * @typedef {object} Consent
  * @property {string} outcome - Consent outcome, derived from responses
- * @property {boolean} answersNeedTriage - Answers need triage?
  * @property {Array} refusalReasons - Unique refusal reasons
  * @property {Array} notes - Consent notes
  */
@@ -48,9 +47,9 @@ export default (patient) => {
       }
     }
 
-    if (answersNeedingTriage.length > 0) {
-      consent.answersNeedTriage = true
+    if (answersNeedingTriage.length > 0 && !patient.triage.completed) {
       patient.triage.outcome = TRIAGE_OUTCOME.NEEDS_TRIAGE
+      patient.triage.completed = true
     }
   }
 

--- a/app/utils/triage-outcome.js
+++ b/app/utils/triage-outcome.js
@@ -16,6 +16,7 @@ export default (patient) => {
   // Triage half, adding triage note and changing outcome to VACCINATE
   if (patient.__triageOutcome) {
     patient.triage.outcome = TRIAGE_OUTCOME.VACCINATE
+    patient.triage.completed = true
 
     // Add example triage note if not already added
     if (patient.__triageNote) {

--- a/app/utils/triage-outcome.js
+++ b/app/utils/triage-outcome.js
@@ -17,8 +17,10 @@ export default (patient) => {
   if (faker.helpers.maybe(() => true, { probability: 0.5 })) {
     patient.triage.outcome = TRIAGE_OUTCOME.VACCINATE
 
-    patient.triage.notes.push(getNote(patient.__triageNote))
-
-    delete patient.__triageNote
+    // Add example triage note if not already added
+    if (patient.__triageNote) {
+      patient.triage.notes.push(getNote(patient.__triageNote))
+      delete patient.__triageNote
+    }
   }
 }

--- a/app/utils/triage-outcome.js
+++ b/app/utils/triage-outcome.js
@@ -14,7 +14,7 @@ export default (patient) => {
   }
 
   // Triage half, adding triage note and changing outcome to VACCINATE
-  if (faker.helpers.maybe(() => true, { probability: 0.5 })) {
+  if (patient.__triageOutcome) {
     patient.triage.outcome = TRIAGE_OUTCOME.VACCINATE
 
     // Add example triage note if not already added

--- a/app/views/_macros/sessions.njk
+++ b/app/views/_macros/sessions.njk
@@ -1,3 +1,4 @@
+{% from "tag/macro.njk" import tag %}
 {% from "_macros/icon.njk" import icon %}
 
 {% macro sessions(campaigns, isOffline) %}
@@ -21,7 +22,11 @@
           {{ campaign.date | govukTime }}
         </td>
         <td class="nhsuk-table__cell">
-          <a href="/campaign/{{ campaign.id }}">{{ campaign.school.name }}</a>
+          <a class="nhsuk-u-margin-right-2" href="/campaign/{{ campaign.id }}">{{ campaign.school.name }}</a>
+          {{ tag({
+            classes: "nhsuk-tag--blue",
+            text: "In progress"
+          }) if campaign.inProgress }}
         </td>
         {% if isOffline %}
           <td class="nhsuk-table__cell nhsuk-u-text-align-right">


### PR DESCRIPTION
* Patients in triage no longer change on page refresh
* Several triage notes without content no longer get applied to patient records
* Show name of the nurse in banner (taking the user name from the more recent triage note)
* Ensure triage action is shown on patient record, instead of remaining as ‘Triage needed’