### PR TITLE
Consent design review (part 2)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -174,7 +174,6 @@ $govuk-assets-path: "/govuk/assets/";
   .nhsuk-table__cell {
     padding-top: nhsuk-spacing(2);
     padding-bottom: nhsuk-spacing(2);
-    vertical-align: middle;
   }
 }
 

--- a/app/globals.js
+++ b/app/globals.js
@@ -207,7 +207,7 @@ export default (_env) => {
       case consent.outcome === CONSENT_OUTCOME.NO_RESPONSE:
         return { text: 'Get consent', colour: 'blue' }
       case consent.outcome === CONSENT_OUTCOME.INCONSISTENT:
-        return { text: 'Review conflicting consent', colour: 'orange' }
+        return { text: 'Check conflicting consent', colour: 'orange' }
       case consent.outcome === CONSENT_OUTCOME.REFUSED:
         return { text: 'Check refusal', colour: 'orange' }
       case consent.outcome === CONSENT_OUTCOME.FINAL_REFUSAL:

--- a/app/globals.js
+++ b/app/globals.js
@@ -241,8 +241,8 @@ export default (_env) => {
    */
   globals.outcome = (patient, consentRecord) => {
     let colour = 'blue'
-    let text = 'test'
-    let description = 'test'
+    let description
+    let text
 
     // Build list of relationships that have responded
     const relationships = []
@@ -261,16 +261,11 @@ export default (_env) => {
 
       switch (patient.outcome) {
         case PATIENT_OUTCOME.COULD_NOT_VACCINATE:
-          colour = 'red'
-          description = patient.outcome
-          break
         case PATIENT_OUTCOME.NO_CONSENT:
           colour = 'red'
-          description = patient.consent.outcome
           break
         default:
           colour = 'green'
-          description = patient.outcome
       }
     } else if (patient.triage.outcome) {
       text = patient.triage.outcome

--- a/app/globals.js
+++ b/app/globals.js
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon'
+import filters from '@x-govuk/govuk-prototype-filters'
 import _ from 'lodash'
 import { CONSENT_OUTCOME, PATIENT_OUTCOME, RESPONSE_CONSENT, RESPONSE_REFUSAL, VACCINATION_SITE, TRIAGE_OUTCOME, VACCINATION_OUTCOME } from './enums.js'
 
@@ -244,6 +244,17 @@ export default (_env) => {
     let text = 'test'
     let description = 'test'
 
+    // Build list of relationships that have responded
+    const relationships = []
+    patient.responses.forEach(response => {
+      if (response.parentOrGuardian.relationship === 'Other') {
+        relationships.push(response.parentOrGuardian.relationshipOther)
+      } else {
+        relationships.push(response.parentOrGuardian.relationship)
+      }
+    })
+    const respondents = filters.formatList(relationships)
+
     // No outcome yet
     if (patient.outcome !== PATIENT_OUTCOME.NO_OUTCOME_YET) {
       text = patient.outcome
@@ -291,10 +302,10 @@ export default (_env) => {
           description = 'No-one responded to our requests for consent.'
           break
         case CONSENT_OUTCOME.ONLY_MENACWY:
-          description = 'Parent or guardian gave consent for MenACWY.'
+          description = `${respondents} gave consent for MenACWY.`
           break
         case CONSENT_OUTCOME.ONLY_3_IN_1:
-          description = 'Parent or guardian gave consent for the 3-in-1 booster.'
+          description = `${respondents} gave consent for the 3-in-1 booster.`
           break
         case CONSENT_OUTCOME.INCONSISTENT:
           description = 'You can only vaccinate if all respondents give consent.'
@@ -304,7 +315,7 @@ export default (_env) => {
           description = `${patient.fullName} is ready to vaccinate`
           break
         default:
-          description = 'Parent or guardian refused to give consent.'
+          description = `${respondents} refused to give consent.`
       }
 
       const isGillickCompetent = consentRecord?.gillickCompetent === 'Yes'

--- a/app/routes/_filters.js
+++ b/app/routes/_filters.js
@@ -139,38 +139,31 @@ export default (req, res) => {
   return {
     noResponse: {
       label: `No response (${noResponseResults.length})`,
-      results: sort(noResponseResults),
-      actionNeeded: true
+      results: sort(noResponseResults)
     },
     consentValid: {
       label: `Consent given (${consentValidResults.length})`,
-      results: sort(consentValidResults),
-      actionNeeded: true
+      results: sort(consentValidResults)
     },
     consentRefused: {
       label: `Consent refused (${consentRefusedResults.length})`,
-      results: sort(consentRefusedResults),
-      actionNeeded: true
+      results: sort(consentRefusedResults)
     },
     consentConflicts: {
       label: `Consent conflicts (${consentConflictsResults.length})`,
-      results: sort(consentConflictsResults),
-      actionNeeded: true
+      results: sort(consentConflictsResults)
     },
     triageNeeded: {
       label: `Triage needed (${triageNeededResults.length})`,
-      results: sort(triageNeededResults),
-      actionNeeded: true
+      results: sort(triageNeededResults)
     },
     triageCompleted: {
       label: `Triage completed (${triageCompletedResults.length})`,
-      results: sort(triageCompletedResults),
-      actionNeeded: true
+      results: sort(triageCompletedResults)
     },
     noTriageNeeded: {
       label: `No triage needed (${noTriageNeededResults.length})`,
-      results: sort(noTriageNeededResults),
-      actionNeeded: true
+      results: sort(noTriageNeededResults)
     },
     readyToVaccinate: {
       label: `Not vaccinated (${readyToVaccinateResults.length})`,
@@ -178,16 +171,18 @@ export default (req, res) => {
     },
     vaccinated: {
       label: `Vaccinated (${vaccinatedResults.length})`,
-      results: sort(vaccinatedResults)
+      results: sort(vaccinatedResults),
+      statusColumn: 'Outcome'
     },
     couldNotVaccinate: {
       label: `Could not vaccinate (${couldNotVaccinateResults.length})`,
-      results: sort(couldNotVaccinateResults)
+      results: sort(couldNotVaccinateResults),
+      statusColumn: 'Outcome'
     },
     actionNeeded: {
       label: `Action needed (${actionNeededResults.length})`,
       results: sort(actionNeededResults),
-      actionNeeded: true,
+      statusColumn: 'Action needed',
       actionNeededFilter: true
     }
   }

--- a/app/views/campaign/_tab.html
+++ b/app/views/campaign/_tab.html
@@ -31,10 +31,17 @@
               </td>
               {% if isRefusalReasonNeeded %}
               <td class="nhsuk-table__cell nhsuk-u-font-size-16">
-                {% for reason in patient.consent.refusalReasons %}
-                  {{ reason | noOrphans | safe }}
-                  {% if not loop.last %}<br>{% endif %}
-                {% endfor %}
+                {% if patient.outcome == PATIENT_OUTCOME.NO_CONSENT %}
+                  {{ tag({
+                    text: "Confirmed",
+                    classes: "nhsuk-tag--red nhsuk-u-font-size-16 nhsuk-u-width-full"
+                  }) }}
+                {% else %}
+                  {% for reason in patient.consent.refusalReasons %}
+                    {{ reason | noOrphans | safe }}
+                    {% if not loop.last %}<br>{% endif %}
+                  {% endfor %}
+                {% endif %}
               </td>
               {% endif %}
               {% if tab.statusColumn %}

--- a/app/views/campaign/_tab.html
+++ b/app/views/campaign/_tab.html
@@ -8,12 +8,13 @@
         <thead class="nhsuk-table__head">
           <tr class="nhsuk-table__row">
             <th class="nhsuk-table__header">Name</th>
-            <th class="nhsuk-table__header">
-              {{- "Reason for refusal" if isRefusalReasonNeeded else "Date of birth" -}}
-            </th>
-            <th class="nhsuk-table__header">
-              {{- "Action needed" if tab.actionNeeded else "Outcome" -}}
-            </th>
+            <th class="nhsuk-table__header app-u-nowrap">Date of birth</th>
+            {% if isRefusalReasonNeeded %}
+            <th class="nhsuk-table__header">Reason for refusal</th>
+            {% endif %}
+            {% if tab.statusColumn %}
+            <th class="nhsuk-table__header">{{ tab.statusColumn }}</th>
+            {% endif %}
           </tr>
         </thead>
         <tbody class="nhsuk-table__body">
@@ -26,24 +27,27 @@
                 {% endif %}
               </td>
               <td class="nhsuk-table__cell nhsuk-u-font-size-16">
-                {% if isRefusalReasonNeeded %}
-                  {% for reason in patient.consent.refusalReasons %}
-                    {{ reason | noOrphans | safe }}
-                    {% if not loop.last %}<br>{% endif %}
-                  {% endfor %}
-                {% else %}
-                  {{ patient.dob | govukDate("truncate") }}
-                {% endif %}
+                {{ patient.dob | govukDate("truncate") }}
               </td>
+              {% if isRefusalReasonNeeded %}
+              <td class="nhsuk-table__cell nhsuk-u-font-size-16">
+                {% for reason in patient.consent.refusalReasons %}
+                  {{ reason | noOrphans | safe }}
+                  {% if not loop.last %}<br>{% endif %}
+                {% endfor %}
+              </td>
+              {% endif %}
+              {% if tab.statusColumn %}
               <td class="nhsuk-table__cell">
                 {{ tag({
                   text: action(patient).text,
                   classes: "nhsuk-tag--" + action(patient).colour + " nhsuk-u-font-size-16 nhsuk-u-width-full"
-                }) if tab.actionNeeded else tag({
+                }) if tab.statusColumn == "Action needed" else tag({
                   text: outcome(patient).text,
                   classes: "nhsuk-tag--" + outcome(patient).colour + " nhsuk-u-font-size-16 nhsuk-u-width-full"
                 }) }}
               </td>
+              {% endif %}
             </tr>
           {% endfor %}
         </tbody>

--- a/app/views/campaign/patient.html
+++ b/app/views/campaign/patient.html
@@ -30,7 +30,7 @@
       {% if patient.outcome == PATIENT_OUTCOME.NO_OUTCOME_YET %}
         {% if triageNeeded %}
           {% include "campaign/patient/_action-triage.html" %}
-        {% elif hasConsented and readyToVaccinate %}
+        {% elif hasConsented and readyToVaccinate and campaign.inProgress %}
           {% include "campaign/patient/_action-vaccinate.html" %}
         {% endif %}
       {% endif %}

--- a/app/views/campaign/patient/_outcome.html
+++ b/app/views/campaign/patient/_outcome.html
@@ -1,11 +1,14 @@
 {% set descriptionHtml %}
-  <p>{{ outcome(patient, consentRecord).description }}</p>
+  {% set description = outcome(patient, consentRecord).description %}
+  {% if description %}
+    <p>{{ description }}</p>
+  {% endif %}
 
   {{ summaryList({
     rows: decorateRows([
       {
         key: "Reason",
-        value: patient.consent.outcome or patient.triage.outcome or vaccination.outcome
+        value: vaccination.outcome or patient.triage.outcome or patient.consent.outcome
       } if not vaccineGiven,
       {
         key: "Vaccine",


### PR DESCRIPTION
* Show relationship names in consent/refusal summary
* Remove status tag from most session tables
* Show confirmed refusal status in consent refused table
* Only show vaccination action panel when a campaign is in progress
* Show correct content in outcome summary panel