### PR TITLE
Add signed in header navigation and sign out route

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -104,6 +104,13 @@ $govuk-assets-path: "/govuk/assets/";
 }
 
 // App components
+.app-header {
+  .nhsuk-header__navigation-item:has(a[href="/vaccines"]) {
+    margin-right: auto;
+  }
+}
+
+
 .app-status {
   align-items: center;
   display: inline-flex;

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,14 +2,15 @@ import express from 'express'
 import getConsentOutcome from './utils/consent-outcome.js'
 import getTriageOutcome from './utils/triage-outcome.js'
 import getPatientOutcome from './utils/patient-outcome.js'
-import vaccinationRoutes from './routes/vaccination.js'
+import accountRoutes from './routes/account.js'
+import campaignRoutes from './routes/campaign.js'
+import consent from './routes/consent.js'
 import daySetupRoutes from './routes/day-setup.js'
 import newCampaignRoutes from './routes/new-campaign.js'
-import campaignRoutes from './routes/campaign.js'
-import userRoutes from './routes/user.js'
-import onlineOfflineRoutes from './routes/online-offline.js'
 import redirects from './routes/redirects.js'
-import consent from './routes/consent.js'
+import onlineOfflineRoutes from './routes/online-offline.js'
+import userRoutes from './routes/user.js'
+import vaccinationRoutes from './routes/vaccination.js'
 import vaccineBatchRoutes from './routes/vaccine-batches.js'
 
 const router = express.Router()
@@ -77,14 +78,15 @@ router.all('*', (req, res, next) => {
   next()
 })
 
-vaccinationRoutes(router)
+accountRoutes(router)
+campaignRoutes(router)
+consent(router)
 daySetupRoutes(router)
 newCampaignRoutes(router)
-campaignRoutes(router)
-userRoutes(router)
 onlineOfflineRoutes(router, hasOfflineChanges)
 redirects(router)
-consent(router)
+userRoutes(router)
+vaccinationRoutes(router)
 vaccineBatchRoutes(router)
 
 export default router

--- a/app/routes/account.js
+++ b/app/routes/account.js
@@ -1,0 +1,6 @@
+export default (router) => {
+  router.get('/account/sign-out', (req, res) => {
+    delete req.session.data.token
+    res.redirect('/')
+  })
+}

--- a/app/views/_layouts/default.html
+++ b/app/views/_layouts/default.html
@@ -29,12 +29,32 @@
   {% endif %}
 
   {{ header({
-    transactionalService: {
+    classes: "app-header",
+    service: {
       name: serviceName,
-      href: "/"
+      href: "/dashboard" if data.token else "/"
     },
-    showNav: "false",
-    showSearch: "false"
+    homeHref: "/dashboard" if data.token else "/",
+    showNav: "true" if data.token else "false",
+    showSearch: "false",
+    primaryLinks: [
+      {
+        url: "/school-sessions",
+        label: "School sessions"
+      },
+      {
+        url: "/vaccines",
+        label: "Manage vaccines"
+      },
+      {
+        url: "#",
+        label: data.user.email
+      },
+      {
+        url: "/account/sign-out",
+        label: "Sign out"
+      }
+    ]
   }) }}
 {% endblock %}
 

--- a/app/views/account/sign-in.html
+++ b/app/views/account/sign-in.html
@@ -23,6 +23,12 @@
           decorate: "user.password"
         }) }}
 
+        {{ input({
+          value: "true",
+          type: "hidden",
+          decorate: "token"
+        }) }}
+
         <p><a href="#">I’ve forgotten my password</a></p>
 
         {{ button({

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -20,7 +20,7 @@
       <p>Manage sessions and record vaccinations</p>
 
       <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
-        <a href="/vaccines">Manage vaccine batches</a>
+        <a href="/vaccines">Manage vaccines</a>
       </h2>
       <p>Add or remove batches</p>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -17,7 +17,7 @@
 
       {{ button({
         text: "Start now",
-        href: "/sign-in"
+        href: "/account/sign-in"
       }) }}
     </div>
   </div>


### PR DESCRIPTION
* Add sign out link (and non-working account link) to header navigation
* Add links to school sessions and manage vaccines views to header navigation
* Set `req.session.data.token` value to `'true'` when signing in
* Delete `req.session.data.token` when signing out
* Only show signed in navigation when `req.session.data.token` is true
* Use alphabetical order for loading routes (hope this doesn’t bite me…)

<img width="1000" alt="Screenshot of signed in header with navigation." src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/676c23fe-4419-4584-8600-11f5d2bacc7e">
