### PR TITLE
Show pre-defined list of parental contacts for get consent response journey

### DIFF
--- a/app/views/consent/index.html
+++ b/app/views/consent/index.html
@@ -3,52 +3,35 @@
 {% set title = "Who are you trying to get consent from?" %}
 
 {% block form %}
-  {{ heading({ caption: patient.fullName, title: title }) }}
-
-  {{ input({
-    label: {
-      text: "Full name"
-    },
-    decorate: ["response", "parentOrGuardian", "fullName"]
-  }) }}
-
-  {{ input({
-    label: {
-      text: "Phone number"
-    },
-    decorate: ["response", "parentOrGuardian", "tel"]
-  }) }}
-
-  {% set other %}
-    <p>They need parental responsibility to give consent.</p>
-    {{ input({
-      label: {
-        text: "Relationship to the child"
-      },
-      hint: {
-        text: "For example, carer"
-      },
-      decorate: ["response", "parentOrGuardian", "relationshipOther"]
-    }) }}
-  {% endset %}
-
   {{ radios({
     fieldset: {
       legend: {
-        text: "Relationship to the child"
+        text: heading({ caption: patient.fullName, title: title }),
+        classes: "nhsuk-fieldset__legend--l"
       }
     },
     items: [
-      { text: "Mum" },
-      { text: "Dad" },
-      { text: "Guardian" },
       {
-        text: "Other",
-        conditional: {
-          html: other
-        }
+        text: exampleParents.a.fullName,
+        label: {
+          classes: "nhsuk-label--s"
+        },
+        hint: {
+          html: patient.address | replace("\n", ", ") + "<br>" + exampleParents.a.tel
+        },
+        value: "a"
+      },
+      {
+        text: exampleParents.b.fullName,
+        label: {
+          classes: "nhsuk-label--s"
+        },
+        hint: {
+          html: patient.address | replace("\n", ", ") + "<br>" + exampleParents.b.tel
+        },
+        value: "b"
       }
     ],
-    decorate: ["response", "parentOrGuardian", "relationship"]
+    decorate: ["exampleParent"]
   }) }}
 {% endblock %}


### PR DESCRIPTION
Instead of allowing user to enter details manually, let them choose from a pre-defined list of contacts (that in theory would come from CHIS records and perhaps other sources). This replaces the journey where details would need to be entered manually.

<img width="650" alt="Screenshot of Who are you trying to get consent from? question page." src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/6f5db6b0-bfb3-4dac-8cac-c1ff2f93f543">
