### PR TITLE
Show detailed reasons for other consent refusal in outcome summary

### DIFF
--- a/app/utils/consent-outcome.js
+++ b/app/utils/consent-outcome.js
@@ -55,13 +55,25 @@ export default (patient) => {
 
   // Build a list of refusal reasons
   const refusalReasons = []
+  const refusalReasonsDetailed = []
   if (outcome === CONSENT_OUTCOME.REFUSED || outcome === CONSENT_OUTCOME.FINAL_REFUSAL) {
     for (const response of Object.values(responses)) {
       if (!response.refusalReason) { continue }
 
-      refusalReasons.push(response.refusalReason)
+      const { refusalReason, refusalReasonOther } = response
+
+      const refusalReasonDetail = refusalReason === 'Other'
+        ? `Other – ${refusalReasonOther}`
+        : refusalReason
+
+      refusalReasons.push(refusalReason)
+      refusalReasonsDetailed.push(refusalReasonDetail)
     }
+    // Refusal reasons (short)
     consent.refusalReasons = [...new Set(refusalReasons)]
+
+    // Refusal reasons (with other provided details)
+    consent.refusalReasonsDetailed = [...new Set(refusalReasonsDetailed)]
   }
 
   // Add value to indicate presence of health answers

--- a/app/views/campaign/patient/_outcome.html
+++ b/app/views/campaign/patient/_outcome.html
@@ -11,11 +11,11 @@
         value: vaccination.outcome or patient.triage.outcome or patient.consent.outcome
       } if not vaccineGiven,
       {
-        key: "Refusal " + (patient.consent.refusalReasons.length | plural("reason", showNumber=false)),
+        key: "Refusal " + (patient.consent.refusalReasonsDetailed.length | plural("reason", showNumber=false)),
         value: {
-          html: patient.consent.refusalReasons.join("<br>")
+          html: patient.consent.refusalReasonsDetailed.join("<br>")
         }
-      } if not vaccineGiven and patient.consent.refusalReasons,
+      } if not vaccineGiven and patient.consent.refusalReasonsDetailed,
       {
         key: "Vaccine",
         value: data.vaccines.batches[vaccination.batch].summary


### PR DESCRIPTION
Previously the summary would only show ‘Other’ for refusal reason, without showing the entered details.

<img width="650" alt="Screenshot of ‘Could not vaccinate’ summary card" src="https://github.com/nhsuk/record-childrens-vaccinations-prototype/assets/813383/ef19da11-0944-44f9-8f9a-f6b637c97583">
